### PR TITLE
feat: add gRPC client and connection state management

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerClient.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerClient.kt
@@ -1,0 +1,71 @@
+package com.snootbeestci.codewalker.grpc
+
+import codewalker.v1.CodeWalkerGrpcKt
+import codewalker.v1.getVersionRequest
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.util.messages.Topic
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+
+@Service
+class CodewalkerClient : Disposable {
+
+    private var channel: ManagedChannel? = null
+    private var stub: CodeWalkerGrpcKt.CodeWalkerCoroutineStub? = null
+
+    var connectionState: ConnectionState = ConnectionState.DISCONNECTED
+        private set
+
+    enum class ConnectionState {
+        DISCONNECTED,
+        INCOMPATIBLE,
+        CONNECTED
+    }
+
+    suspend fun connect(address: String) {
+        disconnect()
+        try {
+            channel = ManagedChannelBuilder.forTarget(address)
+                .usePlaintext()
+                .build()
+            stub = CodeWalkerGrpcKt.CodeWalkerCoroutineStub(channel!!)
+            val version = stub!!.getVersion(getVersionRequest {})
+            connectionState = if (version.protoMajor == SUPPORTED_PROTO_MAJOR) {
+                ConnectionState.CONNECTED
+            } else {
+                ConnectionState.INCOMPATIBLE
+            }
+        } catch (e: Exception) {
+            connectionState = ConnectionState.DISCONNECTED
+        }
+        ApplicationManager.getApplication().messageBus
+            .syncPublisher(CONNECTION_STATE_TOPIC)
+            .stateChanged(connectionState)
+    }
+
+    fun disconnect() {
+        channel?.shutdownNow()
+        channel = null
+        stub = null
+        connectionState = ConnectionState.DISCONNECTED
+    }
+
+    fun getStub(): CodeWalkerGrpcKt.CodeWalkerCoroutineStub? = stub
+
+    override fun dispose() { disconnect() }
+
+    companion object {
+        const val SUPPORTED_PROTO_MAJOR = 1
+        val CONNECTION_STATE_TOPIC: Topic<ConnectionStateListener> =
+            Topic.create("CodewalkerConnectionState", ConnectionStateListener::class.java)
+
+        fun getInstance(): CodewalkerClient =
+            ApplicationManager.getApplication().getService(CodewalkerClient::class.java)
+    }
+}
+
+interface ConnectionStateListener {
+    fun stateChanged(state: CodewalkerClient.ConnectionState)
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerStartupActivity.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerStartupActivity.kt
@@ -1,0 +1,12 @@
+package com.snootbeestci.codewalker.grpc
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.snootbeestci.codewalker.settings.CodewalkerSettings
+
+class CodewalkerStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        val address = CodewalkerSettings.getInstance().state.backendAddress
+        CodewalkerClient.getInstance().connect(address)
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/settings/CodewalkerSettingsConfigurable.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/settings/CodewalkerSettingsConfigurable.kt
@@ -1,13 +1,17 @@
 package com.snootbeestci.codewalker.settings
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.Configurable
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import javax.swing.JComponent
 
 class CodewalkerSettingsConfigurable : Configurable {
     private var panel: CodewalkerSettingsPanel? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun getDisplayName() = "Codewalker"
 
@@ -19,12 +23,15 @@ class CodewalkerSettingsConfigurable : Configurable {
     override fun isModified() = panel?.isModified() ?: false
     override fun apply() {
         panel?.apply()
-        ApplicationManager.getApplication().coroutineScope.launch {
+        scope.launch {
             CodewalkerClient.getInstance().connect(
                 CodewalkerSettings.getInstance().state.backendAddress
             )
         }
     }
     override fun reset() { panel?.reset() }
-    override fun disposeUIResources() { panel = null }
+    override fun disposeUIResources() {
+        scope.cancel()
+        panel = null
+    }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/settings/CodewalkerSettingsConfigurable.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/settings/CodewalkerSettingsConfigurable.kt
@@ -1,6 +1,9 @@
 package com.snootbeestci.codewalker.settings
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.Configurable
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import kotlinx.coroutines.launch
 import javax.swing.JComponent
 
 class CodewalkerSettingsConfigurable : Configurable {
@@ -14,7 +17,14 @@ class CodewalkerSettingsConfigurable : Configurable {
     }
 
     override fun isModified() = panel?.isModified() ?: false
-    override fun apply() { panel?.apply() }
+    override fun apply() {
+        panel?.apply()
+        ApplicationManager.getApplication().coroutineScope.launch {
+            CodewalkerClient.getInstance().connect(
+                CodewalkerSettings.getInstance().state.backendAddress
+            )
+        }
+    }
     override fun reset() { panel?.reset() }
     override fun disposeUIResources() { panel = null }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,5 +17,9 @@
                 parentId="tools"
                 id="com.snootbeestci.codewalker.settings.CodewalkerSettingsConfigurable"
                 displayName="Codewalker"/>
+        <applicationService
+            serviceImplementation="com.snootbeestci.codewalker.grpc.CodewalkerClient"/>
+        <postStartupActivity
+            implementation="com.snootbeestci.codewalker.grpc.CodewalkerStartupActivity"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Summary

- Add `CodewalkerClient` application service: manages a gRPC `ManagedChannel`, tracks `DISCONNECTED / INCOMPATIBLE / CONNECTED` state, and broadcasts state changes via a message-bus topic (`CONNECTION_STATE_TOPIC`)
- Add `CodewalkerStartupActivity`: connects to the configured backend address on project open
- Register both as an `applicationService` and `postStartupActivity` in `plugin.xml`
- Wire `CodewalkerSettingsConfigurable.apply()` to reconnect when the backend address is changed in settings

## Test plan

- [ ] Open a project with a running codewalker backend; verify the plugin connects (`CONNECTED` state)
- [ ] Set an unreachable address in settings and apply; verify state becomes `DISCONNECTED`
- [ ] Connect to a backend with a different proto major version; verify state becomes `INCOMPATIBLE`
- [ ] Verify the channel is shut down cleanly when the IDE exits (`dispose()` called)

https://claude.ai/code/session_01QkhQdn5eZJwQDkPcvns1Z7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkhQdn5eZJwQDkPcvns1Z7)_