### PR TITLE
feat: add tool window skeleton with four UI states

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -48,4 +48,8 @@ class CodewalkerPanel(project: Project) {
 
     fun showLoading() = (root.layout as CardLayout).show(root, "LOADING")
     fun showSession() = (root.layout as CardLayout).show(root, "SESSION")
+
+    fun dispose() {
+        disconnectedPanel.dispose()
+    }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -1,0 +1,51 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.grpc.ConnectionStateListener
+import java.awt.CardLayout
+import javax.swing.JPanel
+
+class CodewalkerPanel(project: Project) {
+
+    val root: JPanel = JPanel(CardLayout())
+
+    private val disconnectedPanel = DisconnectedPanel()
+    private val idlePanel = IdlePanel()
+    private val loadingPanel = LoadingPanel()
+    private val sessionPanel = SessionPanel()
+
+    init {
+        root.add(disconnectedPanel.root, "DISCONNECTED")
+        root.add(idlePanel.root, "IDLE")
+        root.add(loadingPanel.root, "LOADING")
+        root.add(sessionPanel.root, "SESSION")
+
+        project.messageBus.connect(project).subscribe(
+            CodewalkerClient.CONNECTION_STATE_TOPIC,
+            object : ConnectionStateListener {
+                override fun stateChanged(state: CodewalkerClient.ConnectionState) {
+                    ApplicationManager.getApplication().invokeLater { showState(state) }
+                }
+            }
+        )
+
+        showState(CodewalkerClient.getInstance().connectionState)
+    }
+
+    fun showState(state: CodewalkerClient.ConnectionState) {
+        val card = when (state) {
+            CodewalkerClient.ConnectionState.DISCONNECTED,
+            CodewalkerClient.ConnectionState.INCOMPATIBLE -> {
+                disconnectedPanel.update(state)
+                "DISCONNECTED"
+            }
+            CodewalkerClient.ConnectionState.CONNECTED -> "IDLE"
+        }
+        (root.layout as CardLayout).show(root, card)
+    }
+
+    fun showLoading() = (root.layout as CardLayout).show(root, "LOADING")
+    fun showSession() = (root.layout as CardLayout).show(root, "SESSION")
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt
@@ -1,6 +1,7 @@
 package com.snootbeestci.codewalker.toolwindow
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
@@ -10,6 +11,7 @@ class CodewalkerToolWindowFactory : ToolWindowFactory {
         val panel = CodewalkerPanel(project)
         val content = ContentFactory.getInstance()
             .createContent(panel.root, "", false)
+        Disposer.register(toolWindow.disposable) { panel.dispose() }
         toolWindow.contentManager.addContent(content)
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt
@@ -1,0 +1,15 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+
+class CodewalkerToolWindowFactory : ToolWindowFactory {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = CodewalkerPanel(project)
+        val content = ContentFactory.getInstance()
+            .createContent(panel.root, "", false)
+        toolWindow.contentManager.addContent(content)
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/DisconnectedPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/DisconnectedPanel.kt
@@ -5,6 +5,7 @@ import com.snootbeestci.codewalker.settings.CodewalkerSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/DisconnectedPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/DisconnectedPanel.kt
@@ -1,0 +1,59 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.settings.CodewalkerSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.JButton
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class DisconnectedPanel {
+
+    val root: JPanel = JPanel(GridBagLayout())
+    private val messageLabel = JLabel()
+    private val addressLabel = JLabel()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    init {
+        val retryButton = JButton("Retry")
+        retryButton.addActionListener {
+            scope.launch {
+                CodewalkerClient.getInstance().connect(
+                    CodewalkerSettings.getInstance().state.backendAddress
+                )
+            }
+        }
+
+        fun gbc(row: Int) = GridBagConstraints().apply {
+            gridx = 0; gridy = row
+            anchor = GridBagConstraints.CENTER
+            insets = Insets(4, 12, 4, 12)
+        }
+
+        root.add(messageLabel, gbc(0))
+        root.add(addressLabel, gbc(1))
+        root.add(retryButton, gbc(2))
+
+        root.add(JPanel(), GridBagConstraints().apply {
+            gridy = 3; weighty = 1.0; fill = GridBagConstraints.VERTICAL
+        })
+
+        update(CodewalkerClient.ConnectionState.DISCONNECTED)
+    }
+
+    fun update(state: CodewalkerClient.ConnectionState) {
+        messageLabel.text = when (state) {
+            CodewalkerClient.ConnectionState.INCOMPATIBLE ->
+                "Backend version incompatible. Please update your Docker image."
+            else ->
+                "<html>Backend not running. Start it with<br><tt>docker-compose up</tt> in the codewalker directory.</html>"
+        }
+        addressLabel.text = "Backend: ${CodewalkerSettings.getInstance().state.backendAddress}"
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/DisconnectedPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/DisconnectedPanel.kt
@@ -47,6 +47,10 @@ class DisconnectedPanel {
         update(CodewalkerClient.ConnectionState.DISCONNECTED)
     }
 
+    fun dispose() {
+        scope.cancel()
+    }
+
     fun update(state: CodewalkerClient.ConnectionState) {
         messageLabel.text = when (state) {
             CodewalkerClient.ConnectionState.INCOMPATIBLE ->

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
@@ -1,0 +1,61 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import com.intellij.ui.components.JBTextField
+import com.snootbeestci.codewalker.settings.CodewalkerSettings
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.JButton
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
+
+class IdlePanel {
+
+    val root: JPanel = JPanel(GridBagLayout())
+    private val urlField = JBTextField()
+    private val experienceLevelCombo = JComboBox(arrayOf("Junior", "Mid", "Senior"))
+    private val openReviewButton = JButton("Open Review")
+
+    init {
+        val settings = CodewalkerSettings.getInstance()
+        experienceLevelCombo.selectedItem = displayLabel(settings.state.experienceLevel)
+
+        openReviewButton.isEnabled = false
+        urlField.emptyText.text = "Paste a GitHub PR, commit, or comparison URL"
+        urlField.document.addDocumentListener(object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent) = updateButton()
+            override fun removeUpdate(e: DocumentEvent) = updateButton()
+            override fun changedUpdate(e: DocumentEvent) = updateButton()
+            private fun updateButton() {
+                openReviewButton.isEnabled = urlField.text.isNotEmpty()
+            }
+        })
+
+        fun gbc(row: Int, fill: Int = GridBagConstraints.NONE, weightx: Double = 0.0) =
+            GridBagConstraints().apply {
+                gridx = 0; gridy = row
+                this.fill = fill
+                this.weightx = weightx
+                insets = Insets(4, 8, 4, 8)
+                anchor = GridBagConstraints.CENTER
+            }
+
+        root.add(JLabel("Codewalker"), gbc(0))
+        root.add(urlField, gbc(1, GridBagConstraints.HORIZONTAL, 1.0))
+        root.add(experienceLevelCombo, gbc(2, GridBagConstraints.HORIZONTAL, 1.0))
+        root.add(openReviewButton, gbc(3))
+
+        root.add(JPanel(), GridBagConstraints().apply {
+            gridy = 4; weighty = 1.0; fill = GridBagConstraints.VERTICAL
+        })
+    }
+
+    private fun displayLabel(level: String): String = when (level) {
+        "EXPERIENCE_LEVEL_JUNIOR" -> "Junior"
+        "EXPERIENCE_LEVEL_SENIOR" -> "Senior"
+        else -> "Mid"
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/LoadingPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/LoadingPanel.kt
@@ -1,0 +1,37 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.JButton
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+
+class LoadingPanel {
+
+    val root: JPanel = JPanel(GridBagLayout())
+    val progressLabel = JLabel("Loading…")
+
+    init {
+        val progressBar = JProgressBar().apply { isIndeterminate = true }
+        val cancelButton = JButton("Cancel")
+
+        fun gbc(row: Int, fill: Int = GridBagConstraints.NONE, weightx: Double = 0.0) =
+            GridBagConstraints().apply {
+                gridx = 0; gridy = row
+                this.fill = fill
+                this.weightx = weightx
+                insets = Insets(4, 8, 4, 8)
+                anchor = GridBagConstraints.CENTER
+            }
+
+        root.add(progressBar, gbc(0, GridBagConstraints.HORIZONTAL, 1.0))
+        root.add(progressLabel, gbc(1))
+        root.add(cancelButton, gbc(2))
+
+        root.add(JPanel(), GridBagConstraints().apply {
+            gridy = 3; weighty = 1.0; fill = GridBagConstraints.VERTICAL
+        })
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -1,0 +1,15 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class SessionPanel {
+
+    val root: JPanel = JPanel(GridBagLayout())
+
+    init {
+        root.add(JLabel("Session active"), GridBagConstraints())
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,5 +21,10 @@
             serviceImplementation="com.snootbeestci.codewalker.grpc.CodewalkerClient"/>
         <postStartupActivity
             implementation="com.snootbeestci.codewalker.grpc.CodewalkerStartupActivity"/>
+        <toolWindow
+            id="Codewalker"
+            anchor="right"
+            factoryClass="com.snootbeestci.codewalker.toolwindow.CodewalkerToolWindowFactory"
+            icon="/icons/codewalker.svg"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/icons/codewalker.svg
+++ b/src/main/resources/icons/codewalker.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13 13" width="13" height="13">
+  <circle cx="6.5" cy="6.5" r="5.5" fill="none" stroke="#6C707E" stroke-width="1.2"/>
+  <polyline points="4,5 6.5,7.5 9,5" fill="none" stroke="#6C707E" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Closes #4

## Summary

- Registers the Codewalker tool window on the right side of the IDE (`plugin.xml` `toolWindow` extension, anchored right)
- Adds `CodewalkerToolWindowFactory` and `CodewalkerPanel` which switches between four states via `CardLayout`
- **DisconnectedPanel** — shows the configured backend address plus a contextual message (not running vs. incompatible) and a Retry button that triggers `CodewalkerClient.connect()`
- **IdlePanel** — URL field with placeholder text, experience-level combo pre-populated from settings, and an "Open Review" button disabled until the URL field has content
- **LoadingPanel** — indeterminate `JProgressBar`, a status label, and a Cancel button (wired up in issues 5/6)
- **SessionPanel** — placeholder "Session active" label (implemented fully in issues 5/6)
- Adds a 13×13 placeholder SVG icon at `src/main/resources/icons/codewalker.svg`
- Registers a `Disposer` callback on `toolWindow.disposable` so `DisconnectedPanel`'s coroutine scope is cancelled when the tool window is torn down

## Implementation notes

- Connection state changes are subscribed via `project.messageBus.connect(project)` (auto-disposed on project close); UI updates are dispatched to the EDT via `invokeLater`
- Uses `JBTextField` for the URL field and `javax.swing.JComboBox` (not `com.intellij.ui.ComboBox`) per briefing constraints
- `DisconnectedPanel` owns a `CoroutineScope` for the Retry button (same pattern as `CodewalkerSettingsConfigurable`); it is cancelled via `Disposer.register(toolWindow.disposable) { panel.dispose() }` in the factory

## Commits

- `feat: add tool window skeleton with four UI states` — all six Kotlin files, SVG icon, plugin.xml update
- `fix(toolwindow): cancel DisconnectedPanel coroutine scope on dispose` — scope cleanup via `Disposer`
- `fix(toolwindow): import kotlinx.coroutines.cancel in DisconnectedPanel` — missing import caught by CI

## Test plan

- [ ] `./gradlew buildPlugin` passes on CI
- [ ] `./gradlew runIde` shows the Codewalker tool window in a sandboxed IDE on the right side
- [ ] With no backend running, DisconnectedPanel is shown with the "not running" message and backend address
- [ ] Clicking Retry while backend is down keeps the DisconnectedPanel visible
- [ ] After starting the backend, clicking Retry transitions to IdlePanel
- [ ] "Open Review" button is disabled on empty URL field and enabled once text is entered
- [ ] Incompatible backend shows the "version incompatible" message instead