### PR TITLE
Upgrade foojay-resolver-convention Gradle plugin to 1.0.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 rootProject.name = "codewalker-intellij"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }


### PR DESCRIPTION
## Summary
Updates the foojay-resolver-convention Gradle plugin dependency to the latest major version.

## Changes
- Upgraded `org.gradle.toolchains.foojay-resolver-convention` plugin from version 0.8.0 to 1.0.0 in `settings.gradle.kts`

## Details
This update brings the foojay resolver convention plugin to its first stable release, which may include bug fixes, performance improvements, and API stabilization compared to the previous 0.8.0 version.

https://claude.ai/code/session_01DufFXvEkHN2S1Z381ePt1K