### PR TITLE
feat: switch proto stubs to JitPack, pin to v0.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
 
     steps:
       - name: Checkout
@@ -29,8 +28,6 @@ jobs:
 
       - name: Build plugin
         run: ./gradlew buildPlugin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,20 +15,14 @@ kotlin {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://maven.pkg.github.com/snootbeestci/codewalker")
-        credentials {
-            username = providers.environmentVariable("GITHUB_ACTOR").orNull ?: "token"
-            password = providers.environmentVariable("GITHUB_TOKEN").orNull
-        }
-    }
+    maven { url = uri("https://jitpack.io") }
     intellijPlatform {
         defaultRepositories()
     }
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:0.1.9")
+    implementation("com.github.snootbeestci:codewalker-proto:v0.1.0")
     implementation("io.grpc:grpc-okhttp:1.60.0")
     implementation("io.grpc:grpc-kotlin-stub:1.4.1")
     intellijPlatform {

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -33,17 +33,17 @@ JetBrains IDE — PhpStorm, GoLand, WebStorm, PyCharm, IntelliJ IDEA etc.
 ## Proto stubs
 
 The gRPC API is defined in the backend repo. Versioned Kotlin stubs are
-published to GitHub Packages on each backend release and declared as a
-dependency in `build.gradle.kts`:
+served via JitPack and declared as a dependency in `build.gradle.kts`:
 
 ```kotlin
-implementation("com.github.snootbeestci:codewalker-proto:{version}")
+maven { url = uri("https://jitpack.io") }
+
+implementation("com.github.snootbeestci:codewalker-proto:{tag}")
 ```
 
-GitHub Packages requires authentication even for public packages. CI must
-pass `GITHUB_TOKEN` as an env var and declare `packages: read` permission.
-In `build.gradle.kts` the repository block must include a `credentials`
-block reading `GITHUB_ACTOR` / `GITHUB_TOKEN` from environment variables.
+The version string must use the full Git tag (e.g. `v0.1.0`), not a plain
+semver, because JitPack keys builds on the tag name. No credentials are
+needed — JitPack serves public repos without authentication.
 Never copy the `.proto` file into this repo.
 
 ---

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -124,10 +124,9 @@ When opening a review session the plugin resolves a forge token as follows:
 - Collect gRPC flows with `.collect {}` — always handle token, complete, and error variants
 - UI updates must be dispatched via `withContext(Dispatchers.Main)`
 - Prefer `JBTextField`, `JBPasswordField` etc. from `com.intellij.ui.components`
-  over raw Swing equivalents where available
-- **Do not use `com.intellij.ui.ComboBox`** — it lives in `lib/modules/` in
-  IntelliJ 2025.1 and is absent from the plugin compilation classpath; use
-  `javax.swing.JComboBox` instead
+  over raw Swing equivalents — but verify the class is available on the plugin
+  compilation classpath before using it. `com.intellij.ui.ComboBox` is a known
+  example that is absent in IntelliJ 2025.1; use `javax.swing.JComboBox` instead.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed


### PR DESCRIPTION
Replace the GitHub Packages Maven repo (which required GITHUB_TOKEN / GITHUB_ACTOR credentials) with JitPack, which serves the same com.github.snootbeestci:codewalker-proto artefact from the public repo without authentication.  Also pins the dependency to v0.1.0 (JitPack requires the full Git tag, not a plain semver).

Removes the packages: read CI permission and the GITHUB_TOKEN env var from the build step since they are no longer needed.  Updates the briefing to document the new repo source and tag convention.

https://claude.ai/code/session_01DufFXvEkHN2S1Z381ePt1K