### PR TITLE
Issue 5: Wire OpenReviewSession with ReviewSessionController

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -1,0 +1,105 @@
+package com.snootbeestci.codewalker.session
+
+import codewalker.v1.ExperienceLevel
+import codewalker.v1.ForgeContext
+import codewalker.v1.GlossaryTerm
+import codewalker.v1.SessionEvent
+import codewalker.v1.Step
+import codewalker.v1.openReviewSessionRequest
+import com.intellij.credentialStore.CredentialAttributes
+import com.intellij.ide.passwordSafe.PasswordSafe
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.toolwindow.CodewalkerPanel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ReviewSessionController(private val panel: CodewalkerPanel) {
+
+    var sessionId: String? = null
+    var steps: List<Step> = emptyList()
+    var currentStepId: String? = null
+    var glossary: List<GlossaryTerm> = emptyList()
+    var forgeContext: ForgeContext? = null
+    var effectiveLevel: Int = 6
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var sessionJob: Job? = null
+
+    init {
+        panel.loadingPanel.cancelButton.addActionListener { cancel() }
+        panel.idlePanel.setOpenReviewAction { openReview() }
+    }
+
+    private fun openReview() {
+        val url = panel.idlePanel.getUrl()
+        val level = panel.idlePanel.getExperienceLevel()
+        panel.idlePanel.clearError()
+        panel.showLoading()
+
+        sessionJob = scope.launch {
+            try {
+                val stub = CodewalkerClient.getInstance().getStub() ?: run {
+                    withContext(Dispatchers.Main) { panel.showError("Not connected to backend") }
+                    return@launch
+                }
+
+                val expLevel = when (level) {
+                    "EXPERIENCE_LEVEL_JUNIOR" -> ExperienceLevel.EXPERIENCE_LEVEL_JUNIOR
+                    "EXPERIENCE_LEVEL_SENIOR" -> ExperienceLevel.EXPERIENCE_LEVEL_SENIOR
+                    else -> ExperienceLevel.EXPERIENCE_LEVEL_MID
+                }
+
+                val request = openReviewSessionRequest {
+                    this.url = url
+                    experienceLevel = expLevel
+                    forgeToken = resolveForgeToken()
+                }
+
+                stub.openReviewSession(request).collect { event ->
+                    when (event.eventCase) {
+                        SessionEvent.EventCase.PROGRESS -> {
+                            val p = event.progress
+                            withContext(Dispatchers.Main) {
+                                panel.loadingPanel.updateProgress(p.message, p.percent)
+                            }
+                        }
+                        SessionEvent.EventCase.REVIEW_READY -> {
+                            val ready = event.reviewReady
+                            sessionId = ready.sessionId
+                            steps = ready.stepsList
+                            currentStepId = ready.entryStepId
+                            glossary = ready.glossaryList
+                            forgeContext = if (ready.hasForgeContext()) ready.forgeContext else null
+                            effectiveLevel = ready.effectiveLevel
+                            withContext(Dispatchers.Main) { panel.showSession() }
+                        }
+                        SessionEvent.EventCase.ERROR -> {
+                            val msg = event.error.message
+                            withContext(Dispatchers.Main) { panel.showError(msg) }
+                        }
+                        else -> {}
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val msg = e.message ?: "Unknown error"
+                withContext(Dispatchers.Main) { panel.showError(msg) }
+            }
+        }
+    }
+
+    private fun cancel() {
+        sessionJob?.cancel()
+        sessionJob = null
+        panel.showState(CodewalkerClient.getInstance().connectionState)
+    }
+
+    private fun resolveForgeToken(): String =
+        PasswordSafe.instance.getPassword(CredentialAttributes("Codewalker.GitHubToken")) ?: ""
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -92,6 +93,11 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                 withContext(Dispatchers.Main) { panel.showError(msg) }
             }
         }
+    }
+
+    fun dispose() {
+        cancel()
+        scope.cancel()
     }
 
     private fun cancel() {

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -1,10 +1,10 @@
 package com.snootbeestci.codewalker.session
 
-import codewalker.v1.ExperienceLevel
-import codewalker.v1.ForgeContext
-import codewalker.v1.GlossaryTerm
-import codewalker.v1.SessionEvent
-import codewalker.v1.Step
+import codewalker.v1.Codewalker.ExperienceLevel
+import codewalker.v1.Codewalker.ForgeContext
+import codewalker.v1.Codewalker.GlossaryTerm
+import codewalker.v1.Codewalker.SessionEvent
+import codewalker.v1.Codewalker.Step
 import codewalker.v1.openReviewSessionRequest
 import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.ide.passwordSafe.PasswordSafe

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -16,6 +16,7 @@ class CodewalkerPanel(project: Project) {
     internal val idlePanel = IdlePanel()
     internal val loadingPanel = LoadingPanel()
     private val sessionPanel = SessionPanel()
+    private val controller = ReviewSessionController(this)
 
     init {
         root.add(disconnectedPanel.root, "DISCONNECTED")
@@ -33,7 +34,6 @@ class CodewalkerPanel(project: Project) {
         )
 
         showState(CodewalkerClient.getInstance().connectionState)
-        ReviewSessionController(this)
     }
 
     fun showState(state: CodewalkerClient.ConnectionState) {
@@ -57,6 +57,7 @@ class CodewalkerPanel(project: Project) {
     }
 
     fun dispose() {
+        controller.dispose()
         disconnectedPanel.dispose()
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
 import com.snootbeestci.codewalker.grpc.ConnectionStateListener
+import com.snootbeestci.codewalker.session.ReviewSessionController
 import java.awt.CardLayout
 import javax.swing.JPanel
 
@@ -12,8 +13,8 @@ class CodewalkerPanel(project: Project) {
     val root: JPanel = JPanel(CardLayout())
 
     private val disconnectedPanel = DisconnectedPanel()
-    private val idlePanel = IdlePanel()
-    private val loadingPanel = LoadingPanel()
+    internal val idlePanel = IdlePanel()
+    internal val loadingPanel = LoadingPanel()
     private val sessionPanel = SessionPanel()
 
     init {
@@ -32,6 +33,7 @@ class CodewalkerPanel(project: Project) {
         )
 
         showState(CodewalkerClient.getInstance().connectionState)
+        ReviewSessionController(this)
     }
 
     fun showState(state: CodewalkerClient.ConnectionState) {
@@ -48,6 +50,11 @@ class CodewalkerPanel(project: Project) {
 
     fun showLoading() = (root.layout as CardLayout).show(root, "LOADING")
     fun showSession() = (root.layout as CardLayout).show(root, "SESSION")
+
+    fun showError(message: String) {
+        idlePanel.showError(message)
+        (root.layout as CardLayout).show(root, "IDLE")
+    }
 
     fun dispose() {
         disconnectedPanel.dispose()

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
@@ -1,5 +1,6 @@
 package com.snootbeestci.codewalker.toolwindow
 
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBTextField
 import com.snootbeestci.codewalker.settings.CodewalkerSettings
 import java.awt.GridBagConstraints
@@ -18,6 +19,10 @@ class IdlePanel {
     private val urlField = JBTextField()
     private val experienceLevelCombo = JComboBox(arrayOf("Junior", "Mid", "Senior"))
     private val openReviewButton = JButton("Open Review")
+    private val errorLabel = JLabel("").apply {
+        foreground = JBColor.RED
+        isVisible = false
+    }
 
     init {
         val settings = CodewalkerSettings.getInstance()
@@ -47,10 +52,34 @@ class IdlePanel {
         root.add(urlField, gbc(1, GridBagConstraints.HORIZONTAL, 1.0))
         root.add(experienceLevelCombo, gbc(2, GridBagConstraints.HORIZONTAL, 1.0))
         root.add(openReviewButton, gbc(3))
+        root.add(errorLabel, gbc(4, GridBagConstraints.HORIZONTAL, 1.0))
 
         root.add(JPanel(), GridBagConstraints().apply {
-            gridy = 4; weighty = 1.0; fill = GridBagConstraints.VERTICAL
+            gridy = 5; weighty = 1.0; fill = GridBagConstraints.VERTICAL
         })
+    }
+
+    fun getUrl(): String = urlField.text
+    fun getExperienceLevel(): String = selectedExperienceLevel()
+
+    fun setOpenReviewAction(action: () -> Unit) {
+        openReviewButton.addActionListener { action() }
+    }
+
+    fun showError(message: String) {
+        errorLabel.text = message
+        errorLabel.isVisible = true
+    }
+
+    fun clearError() {
+        errorLabel.text = ""
+        errorLabel.isVisible = false
+    }
+
+    private fun selectedExperienceLevel(): String = when (experienceLevelCombo.selectedItem) {
+        "Junior" -> "EXPERIENCE_LEVEL_JUNIOR"
+        "Senior" -> "EXPERIENCE_LEVEL_SENIOR"
+        else -> "EXPERIENCE_LEVEL_MID"
     }
 
     private fun displayLabel(level: String): String = when (level) {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/LoadingPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/LoadingPanel.kt
@@ -12,11 +12,10 @@ class LoadingPanel {
 
     val root: JPanel = JPanel(GridBagLayout())
     val progressLabel = JLabel("Loading…")
+    val progressBar = JProgressBar(0, 100).apply { isIndeterminate = false }
+    val cancelButton = JButton("Cancel")
 
     init {
-        val progressBar = JProgressBar().apply { isIndeterminate = true }
-        val cancelButton = JButton("Cancel")
-
         fun gbc(row: Int, fill: Int = GridBagConstraints.NONE, weightx: Double = 0.0) =
             GridBagConstraints().apply {
                 gridx = 0; gridy = row
@@ -33,5 +32,10 @@ class LoadingPanel {
         root.add(JPanel(), GridBagConstraints().apply {
             gridy = 3; weighty = 1.0; fill = GridBagConstraints.VERTICAL
         })
+    }
+
+    fun updateProgress(message: String, percent: Int) {
+        progressLabel.text = message
+        progressBar.value = percent
     }
 }


### PR DESCRIPTION
## Summary

Closes #5. Wires the "Open Review" button in `IdlePanel` to the `OpenReviewSession` gRPC call, streams progress into `LoadingPanel`, and transitions to `SessionPanel` on `ReviewReady`.

## Changes

### `build.gradle.kts`
- `kotlinx-coroutines-core` switched from `implementation` (transitive) to `compileOnly` — IntelliJ ships its own coroutines runtime and bundling a second copy causes classloader conflicts
- Excluded the transitive `kotlinx-coroutines-core` pull from `grpc-kotlin-stub`, which was the sole source of the bundled copy

### `LoadingPanel`
- Promoted `progressBar` and `cancelButton` from `init`-local variables to class-level `val`s so `ReviewSessionController` can wire and update them
- Progress bar changed from indeterminate to deterministic (`JProgressBar(0, 100)`, `isIndeterminate = false`)
- Added `updateProgress(message: String, percent: Int)` to push `SessionProgress` events into the UI

### `IdlePanel`
- Added `private val errorLabel` (red, hidden by default) with `showError()` / `clearError()` methods
- Exposed `getUrl()`, `getExperienceLevel()`, and `setOpenReviewAction()` for controller wiring
- Added private `selectedExperienceLevel()` that maps the combo selection to the proto enum string
- `errorLabel` sits at row 4; spacer moved to row 5

### `CodewalkerPanel`
- `idlePanel` and `loadingPanel` changed from `private` to `internal` so `ReviewSessionController` (sibling package, same module) can wire them
- Added `showError(message: String)`: delegates to `idlePanel.showError()` then flips card to `IDLE`
- `controller` stored as `private val` so `dispose()` can reach it
- `dispose()` now calls `controller.dispose()` before `disconnectedPanel.dispose()`

### `ReviewSessionController` (new — `session/ReviewSessionController.kt`)
- Owns active session state: `sessionId`, `steps`, `currentStepId`, `glossary`, `forgeContext`, `effectiveLevel`
- `CoroutineScope(SupervisorJob() + Dispatchers.IO)` — all gRPC work is off the UI thread
- `openReview()`: resolves forge token from `PasswordSafe`, calls `OpenReviewSession`, and collects the stream:
  - `PROGRESS` → `panel.loadingPanel.updateProgress()`
  - `REVIEW_READY` → stores session state, calls `panel.showSession()`
  - `ERROR` → calls `panel.showError()`
  - `CancellationException` is rethrown to honour structured cancellation
- `cancel()`: cancels the running job and calls `panel.showState()` to restore the correct card
- `dispose()`: calls `cancel()` then `scope.cancel()` to release the `SupervisorJob`
- `resolveForgeToken()`: reads from `PasswordSafe` with key `"Codewalker.GitHubToken"`; returns empty string (public-repo mode) if absent
- Proto message types imported as `codewalker.v1.Codewalker.Step` etc. (nested inside the `Codewalker` outer class, since the proto file has no `java_multiple_files` option)