### PR TITLE
fix: use compileOnly for kotlinx-coroutines to avoid conflict with In…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,10 @@ repositories {
 dependencies {
     implementation("com.github.snootbeestci:codewalker-proto:v0.1.0")
     implementation("io.grpc:grpc-okhttp:1.60.0")
-    implementation("io.grpc:grpc-kotlin-stub:1.4.1")
+    implementation("io.grpc:grpc-kotlin-stub:1.4.1") {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    }
+    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     intellijPlatform {
         create(providers.gradleProperty("platformType").get(), providers.gradleProperty("platformVersion").get())
         pluginVerifier()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.1.9")
+    implementation("com.github.snootbeestci:codewalker-proto:v0.1.0")
     implementation("io.grpc:grpc-okhttp:1.60.0")
     implementation("io.grpc:grpc-kotlin-stub:1.4.1") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.1.0")
+    implementation("com.github.snootbeestci:codewalker-proto:v0.1.9")
     implementation("io.grpc:grpc-okhttp:1.60.0")
     implementation("io.grpc:grpc-kotlin-stub:1.4.1") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")


### PR DESCRIPTION
…telliJ runtime

IntelliJ ships its own kotlinx-coroutines-core at runtime; bundling a second copy causes classloader conflicts. Switch to compileOnly so the coroutines API is available at compile time but not packaged into the plugin jar. Also exclude the transitive pull from grpc-kotlin-stub, which is the only dependency that brings it in.

https://claude.ai/code/session_01PEMPVoop8bHvCmB9TGTT9s