### PR TITLE
feat: implement navigation and narration (issue #6)

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
@@ -1,0 +1,76 @@
+package com.snootbeestci.codewalker.session
+
+import codewalker.v1.Codewalker.NavigateRequest
+import codewalker.v1.Codewalker.SimpleDirection
+import codewalker.v1.navigateRequest
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.toolwindow.SessionPanel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class NavigationController(
+    private val controller: ReviewSessionController,
+    private val panel: SessionPanel
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var navigateJob: Job? = null
+
+    fun navigateForward() = navigate(navigateRequest {
+        sessionId = controller.sessionId!!
+        direction = SimpleDirection.SIMPLE_DIRECTION_FORWARD
+    })
+
+    fun navigateBack() = navigate(navigateRequest {
+        sessionId = controller.sessionId!!
+        direction = SimpleDirection.SIMPLE_DIRECTION_BACK
+    })
+
+    fun navigateTo(stepId: String) = navigate(navigateRequest {
+        sessionId = controller.sessionId!!
+        this.stepId = stepId
+    })
+
+    private fun navigate(request: NavigateRequest) {
+        navigateJob?.cancel()
+        navigateJob = scope.launch {
+            withContext(Dispatchers.Main) { panel.clearNarration() }
+            val stub = CodewalkerClient.getInstance().getStub() ?: run {
+                withContext(Dispatchers.Main) {
+                    panel.appendNarrationToken("[Error: not connected to backend]")
+                }
+                return@launch
+            }
+            try {
+                stub.navigate(request).collect { event ->
+                    when {
+                        event.hasToken() -> withContext(Dispatchers.Main) {
+                            panel.appendNarrationToken(event.token.text)
+                        }
+                        event.hasComplete() -> withContext(Dispatchers.Main) {
+                            panel.onStepComplete(event.complete)
+                        }
+                        event.hasError() -> withContext(Dispatchers.Main) {
+                            panel.appendNarrationToken("\n[Error: ${event.error.message}]")
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    panel.appendNarrationToken("\n[Error: ${e.message ?: "Unknown error"}]")
+                }
+            }
+        }
+    }
+
+    fun dispose() {
+        scope.cancel()
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -49,7 +49,10 @@ class CodewalkerPanel(project: Project) {
     }
 
     fun showLoading() = (root.layout as CardLayout).show(root, "LOADING")
-    fun showSession() = (root.layout as CardLayout).show(root, "SESSION")
+    fun showSession() {
+        sessionPanel.bind(controller)
+        (root.layout as CardLayout).show(root, "SESSION")
+    }
 
     fun showError(message: String) {
         idlePanel.showError(message)
@@ -58,6 +61,7 @@ class CodewalkerPanel(project: Project) {
 
     fun dispose() {
         controller.dispose()
+        sessionPanel.dispose()
         disconnectedPanel.dispose()
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -1,15 +1,261 @@
 package com.snootbeestci.codewalker.toolwindow
 
+import codewalker.v1.Codewalker.EdgeLabel
+import codewalker.v1.Codewalker.Step
+import codewalker.v1.Codewalker.StepComplete
+import com.intellij.ui.components.JBScrollPane
+import com.snootbeestci.codewalker.session.NavigationController
+import com.snootbeestci.codewalker.session.ReviewSessionController
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.Font
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.BorderFactory
+import javax.swing.DefaultListModel
+import javax.swing.JButton
 import javax.swing.JLabel
+import javax.swing.JList
 import javax.swing.JPanel
+import javax.swing.JTextPane
+import javax.swing.ListSelectionModel
+import javax.swing.SwingConstants
 
 class SessionPanel {
 
     val root: JPanel = JPanel(GridBagLayout())
 
+    private val titleLabel = JLabel("Codewalker")
+    private val languageLabel = JLabel(" ")
+    private val levelLabel = JLabel(" ")
+    private val breadcrumbLabel = JLabel(" ")
+    private val stepListModel = DefaultListModel<StepListItem>()
+    private val stepList = JList(stepListModel).apply {
+        selectionMode = ListSelectionModel.SINGLE_SELECTION
+        cellRenderer = StepListRenderer()
+    }
+    private val narrationPane = JTextPane().apply {
+        isEditable = false
+    }
+    private val backButton = JButton("← Back").apply { isEnabled = false }
+    private val forwardButton = JButton("Forward →").apply { isEnabled = false }
+
+    private var controller: ReviewSessionController? = null
+    private var navigationController: NavigationController? = null
+
     init {
-        root.add(JLabel("Session active"), GridBagConstraints())
+        buildLayout()
+        wireListeners()
+    }
+
+    private fun buildLayout() {
+        val header = JPanel(GridBagLayout()).apply {
+            border = BorderFactory.createEmptyBorder(6, 8, 6, 8)
+            titleLabel.font = titleLabel.font.deriveFont(Font.BOLD)
+            add(titleLabel, GridBagConstraints().apply {
+                gridx = 0; gridy = 0; anchor = GridBagConstraints.WEST
+                insets = Insets(0, 0, 0, 8)
+            })
+            add(languageLabel, GridBagConstraints().apply {
+                gridx = 1; gridy = 0; anchor = GridBagConstraints.WEST
+                insets = Insets(0, 0, 0, 8)
+            })
+            add(JPanel().apply { isOpaque = false }, GridBagConstraints().apply {
+                gridx = 2; gridy = 0; weightx = 1.0; fill = GridBagConstraints.HORIZONTAL
+            })
+            add(levelLabel, GridBagConstraints().apply {
+                gridx = 3; gridy = 0; anchor = GridBagConstraints.EAST
+            })
+        }
+
+        breadcrumbLabel.border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
+
+        val stepListScroll = JBScrollPane(stepList).apply {
+            preferredSize = Dimension(220, 200)
+            minimumSize = Dimension(160, 120)
+        }
+
+        val narrationScroll = JBScrollPane(narrationPane).apply {
+            preferredSize = Dimension(360, 200)
+            minimumSize = Dimension(200, 120)
+        }
+
+        val navBar = JPanel(GridBagLayout()).apply {
+            border = BorderFactory.createEmptyBorder(4, 8, 6, 8)
+            add(backButton, GridBagConstraints().apply {
+                gridx = 0; gridy = 0; anchor = GridBagConstraints.WEST
+                insets = Insets(0, 0, 0, 8)
+            })
+            add(JPanel().apply { isOpaque = false }, GridBagConstraints().apply {
+                gridx = 1; gridy = 0; weightx = 1.0; fill = GridBagConstraints.HORIZONTAL
+            })
+            add(forwardButton, GridBagConstraints().apply {
+                gridx = 2; gridy = 0; anchor = GridBagConstraints.EAST
+            })
+        }
+
+        val body = JPanel(BorderLayout()).apply {
+            add(stepListScroll, BorderLayout.WEST)
+            add(narrationScroll, BorderLayout.CENTER)
+        }
+
+        fun row(component: Component, gridy: Int, weighty: Double, fill: Int) {
+            root.add(component, GridBagConstraints().apply {
+                gridx = 0; this.gridy = gridy
+                weightx = 1.0; this.weighty = weighty
+                this.fill = fill
+            })
+        }
+
+        row(header, 0, 0.0, GridBagConstraints.HORIZONTAL)
+        row(breadcrumbLabel, 1, 0.0, GridBagConstraints.HORIZONTAL)
+        row(body, 2, 1.0, GridBagConstraints.BOTH)
+        row(navBar, 3, 0.0, GridBagConstraints.HORIZONTAL)
+    }
+
+    private fun wireListeners() {
+        backButton.addActionListener { navigationController?.navigateBack() }
+        forwardButton.addActionListener { navigationController?.navigateForward() }
+        stepList.addListSelectionListener { event ->
+            if (event.valueIsAdjusting) return@addListSelectionListener
+            val item = stepList.selectedValue ?: return@addListSelectionListener
+            if (item is StepListItem.Header) {
+                stepList.clearSelection()
+                return@addListSelectionListener
+            }
+            val row = item as StepListItem.StepRow
+            if (row.stepId == controller?.currentStepId) return@addListSelectionListener
+            navigationController?.navigateTo(row.stepId)
+        }
+    }
+
+    fun bind(controller: ReviewSessionController) {
+        this.controller = controller
+        this.navigationController?.dispose()
+        this.navigationController = NavigationController(controller, this)
+        updateLanguageBadge(controller)
+        updateLevelPips(controller.effectiveLevel)
+        populateStepList(controller.steps)
+        updateBreadcrumb(listOf(controller.forgeContext?.prTitle?.takeIf { it.isNotEmpty() } ?: "Review"))
+        clearNarration()
+        backButton.isEnabled = false
+        forwardButton.isEnabled = false
+        root.revalidate()
+        root.repaint()
+        controller.currentStepId?.let { navigationController?.navigateTo(it) }
+    }
+
+    fun dispose() {
+        navigationController?.dispose()
+        navigationController = null
+    }
+
+    fun clearNarration() {
+        narrationPane.text = ""
+    }
+
+    fun appendNarrationToken(text: String) {
+        val doc = narrationPane.document
+        doc.insertString(doc.length, text, null)
+        narrationPane.caretPosition = doc.length
+    }
+
+    fun onStepComplete(complete: StepComplete) {
+        controller?.currentStepId = complete.stepId
+        updateBreadcrumb(complete.breadcrumbList)
+        updateStepHighlight(complete.stepId)
+        val hasForward = complete.availableEdgesList.any {
+            it.label == EdgeLabel.EDGE_LABEL_NEXT && it.navigable
+        }
+        forwardButton.isEnabled = hasForward
+        backButton.isEnabled = complete.breadcrumbList.size > 1
+    }
+
+    private fun updateBreadcrumb(crumbs: List<String>) {
+        breadcrumbLabel.text = if (crumbs.isEmpty()) " " else crumbs.joinToString(" › ")
+    }
+
+    private fun updateStepHighlight(stepId: String) {
+        val idx = (0 until stepListModel.size).firstOrNull {
+            val item = stepListModel.getElementAt(it)
+            item is StepListItem.StepRow && item.stepId == stepId
+        }
+        if (idx != null) {
+            stepList.selectedIndex = idx
+            stepList.ensureIndexIsVisible(idx)
+        } else {
+            stepList.clearSelection()
+        }
+    }
+
+    private fun populateStepList(steps: List<Step>) {
+        stepListModel.clear()
+        val grouped = LinkedHashMap<String, MutableList<Step>>()
+        for (step in steps) {
+            val path = step.hunkSpan.filePath.ifEmpty { "(unknown)" }
+            grouped.getOrPut(path) { mutableListOf() }.add(step)
+        }
+        for ((path, fileSteps) in grouped) {
+            stepListModel.addElement(StepListItem.Header(path))
+            fileSteps.forEachIndexed { index, step ->
+                val span = step.hunkSpan
+                val end = span.newStart + maxOf(span.newLines, 1) - 1
+                val rangeLabel = "${span.newStart}–$end"
+                val label = step.label.ifEmpty { "Hunk ${index + 1} (lines $rangeLabel)" }
+                stepListModel.addElement(StepListItem.StepRow(step.id, label))
+            }
+        }
+    }
+
+    private fun updateLanguageBadge(controller: ReviewSessionController) {
+        val files = controller.forgeContext?.filesList.orEmpty()
+        val language = files.firstOrNull { it.language.isNotEmpty() }?.language ?: ""
+        languageLabel.text = if (language.isEmpty()) " " else "[$language]"
+    }
+
+    private fun updateLevelPips(level: Int) {
+        val capped = level.coerceIn(0, MAX_LEVEL)
+        levelLabel.text = "●".repeat(capped) + "○".repeat(MAX_LEVEL - capped)
+    }
+
+    private sealed class StepListItem {
+        data class Header(val filePath: String) : StepListItem()
+        data class StepRow(val stepId: String, val label: String) : StepListItem()
+    }
+
+    private class StepListRenderer : javax.swing.ListCellRenderer<StepListItem> {
+        private val delegate = javax.swing.DefaultListCellRenderer()
+
+        override fun getListCellRendererComponent(
+            list: JList<out StepListItem>,
+            value: StepListItem,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean
+        ): Component {
+            val text = when (value) {
+                is StepListItem.Header -> value.filePath
+                is StepListItem.StepRow -> "    " + value.label
+            }
+            val showSelected = isSelected && value is StepListItem.StepRow
+            val component = delegate.getListCellRendererComponent(
+                list, text, index, showSelected, cellHasFocus
+            ) as JLabel
+            if (value is StepListItem.Header) {
+                component.font = component.font.deriveFont(Font.BOLD)
+                component.horizontalAlignment = SwingConstants.LEFT
+                component.background = list.background
+                component.foreground = list.foreground
+            } else {
+                component.font = component.font.deriveFont(Font.PLAIN)
+            }
+            return component
+        }
+    }
+
+    companion object {
+        private const val MAX_LEVEL = 10
     }
 }


### PR DESCRIPTION
## Summary

Implements the active session UI from issue #6, replacing the `SessionPanel` stub with a full layout and adding a `NavigationController` that drives the `Navigate` streaming RPC.

### Commits in this PR

- **feat: implement navigation and narration** — adds `NavigationController`, replaces `SessionPanel` with the real layout, wires `bind()` from `CodewalkerPanel.showSession()`.

### What changed

**New file `session/NavigationController.kt`**
- `navigateForward()`, `navigateBack()`, `navigateTo(stepId)` build a `NavigateRequest` via the `navigateRequest { … }` DSL and call `stub.navigate(request)`.
- Streams `NarrateEvent`s: token → `appendNarrationToken`, complete → `onStepComplete`, error → inline error message.
- All UI updates dispatched via `withContext(Dispatchers.Main)`.
- Cancels any in-flight navigate job before starting a new one so concurrent clicks don't interleave.
- Scope uses `Dispatchers.IO` to match `ReviewSessionController`.

**`SessionPanel.kt` — replaced stub**
- `GridBagLayout` with four regions: header (title + language badge + level pip bar), breadcrumb label, body (grouped step list `JList` + narration `JTextPane`), nav bar.
- Step list backed by a `DefaultListModel<StepListItem>` where `StepListItem` is a private sealed class (`Header` / `StepRow`). Steps are grouped by `HunkSpan.filePath`; headers are non-selectable (any selection on a header is cleared).
- Custom `ListCellRenderer` makes header rows bold and prevents selection highlight on them.
- `bind(controller)` populates state, clears narration, and auto-navigates to the entry step. Recreates the `NavigationController` on each bind and disposes the previous one.
- `onStepComplete` updates the breadcrumb, highlights the active step, enables Forward only when an `EDGE_LABEL_NEXT` edge is present and `navigable`, and enables Back when the breadcrumb has more than one entry.
- Language badge reads the first non-empty `language` from `forgeContext.filesList`. Level pips render `controller.effectiveLevel` filled bullets out of 10.

**`CodewalkerPanel.kt`**
- `showSession()` now calls `sessionPanel.bind(controller)` before showing the SESSION card.
- `dispose()` also disposes the `SessionPanel` (which disposes the `NavigationController`).

### Notes / deviations from the issue example

- Step list model is `DefaultListModel<StepListItem>` (sealed class) rather than `DefaultListModel<String>`. The acceptance criteria require non-selectable file headers and selectable step rows that map back to step IDs — a String model can't cleanly carry both. The behaviour described in `updateStepHighlight`, `populateStepList`, and the click handler matches the spec.
- `NavigationController` scope uses `Dispatchers.IO` (matches `ReviewSessionController`) instead of `Dispatchers.Default` from the example. Both satisfy the briefing rule of never blocking the UI thread.

### Briefing / README

The briefing's "Session model" section already documents `NavigationController` as the component that handles `Navigate` RPC calls and streams tokens to the UI, so no briefing update is needed. The README's user-facing description of the feature is unchanged.

## Test plan

- [ ] `./gradlew check` — **could not run in the sandbox**: outbound HTTPS to `jitpack.io` and `*.jetbrains.com` returns 403 (`x-deny-reason: host_not_allowed`), so neither the `codewalker-proto` artifact nor the IntelliJ Platform IC distribution can be resolved. Needs a maintainer run on a machine with network access.
- [ ] `./gradlew runIde` — manual end-to-end against a running backend: open a PR, walk forward through hunks, walk back, click a step in the list, observe streaming narration and updated breadcrumb / highlight.
- [ ] Forward button is disabled at the final hunk; Back button is disabled on the entry step.

https://claude.ai/code/session_019xN537iZViU2RDYHeyBedg

---
_Generated by [Claude Code](https://claude.ai/code/session_019xN537iZViU2RDYHeyBedg)_