### PR TITLE
feat: highlight current step's lines in IDE editor

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -127,6 +127,10 @@ When opening a review session the plugin resolves a forge token as follows:
   over raw Swing equivalents — but verify the class is available on the plugin
   compilation classpath before using it. `com.intellij.ui.ComboBox` is a known
   example that is absent in IntelliJ 2025.1; use `javax.swing.JComboBox` instead.
+- Editor integration uses `FileEditorManager.openTextEditor()` to open files
+  and `editor.markupModel.addRangeHighlighter()` for transient highlights.
+  Always call `RangeHighlighter.dispose()` to clean up — never let highlights
+  accumulate across sessions.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -131,6 +131,10 @@ When opening a review session the plugin resolves a forge token as follows:
   and `editor.markupModel.addRangeHighlighter()` for transient highlights.
   Always call `RangeHighlighter.dispose()` to clean up — never let highlights
   accumulate across sessions.
+- Index lookups (`FilenameIndex`, `ProjectFileIndex`, PSI traversal etc.)
+  require a read action — wrap them in `ReadAction.compute { ... }` when
+  called from the EDT or a coroutine, otherwise IntelliJ throws
+  "Read access is allowed from inside read-action only".
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -1,0 +1,83 @@
+package com.snootbeestci.codewalker.editor
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.ui.JBColor
+import java.awt.Color
+
+class EditorHighlighter(private val project: Project) {
+
+    private var currentHighlighters: List<RangeHighlighter> = emptyList()
+    private var currentEditor: Editor? = null
+
+    fun highlightHunk(filePath: String, newStart: Int, newLines: Int) {
+        clearHighlight()
+
+        val virtualFile = findFile(filePath) ?: return
+        val editor = openOrFocus(virtualFile) ?: return
+
+        currentEditor = editor
+
+        val document = editor.document
+        val startOffset = document.getLineStartOffset((newStart - 1).coerceAtLeast(0))
+        val endLine = (newStart + newLines - 2).coerceAtMost(document.lineCount - 1)
+        val endOffset = document.getLineEndOffset(endLine)
+
+        val attributes = TextAttributes().apply {
+            backgroundColor = JBColor(
+                Color(255, 240, 200),
+                Color(80, 70, 30)
+            )
+        }
+
+        val highlighter = editor.markupModel.addRangeHighlighter(
+            startOffset,
+            endOffset,
+            HighlighterLayer.SELECTION - 1,
+            attributes,
+            HighlighterTargetArea.EXACT_RANGE
+        )
+
+        currentHighlighters = listOf(highlighter)
+
+        editor.scrollingModel.scrollTo(
+            LogicalPosition(newStart - 1, 0),
+            ScrollType.CENTER
+        )
+    }
+
+    fun clearHighlight() {
+        currentHighlighters.forEach { it.dispose() }
+        currentHighlighters = emptyList()
+        currentEditor = null
+    }
+
+    private fun findFile(filePath: String): VirtualFile? {
+        val fileName = filePath.substringAfterLast('/')
+        return FilenameIndex.getVirtualFilesByName(
+            fileName,
+            GlobalSearchScope.projectScope(project)
+        ).firstOrNull { it.path.endsWith(filePath) }
+    }
+
+    private fun openOrFocus(file: VirtualFile): Editor? {
+        val descriptor = OpenFileDescriptor(project, file)
+        return FileEditorManager.getInstance(project)
+            .openTextEditor(descriptor, true)
+    }
+
+    fun dispose() {
+        clearHighlight()
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -1,6 +1,7 @@
 package com.snootbeestci.codewalker.editor
 
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
@@ -11,6 +12,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
@@ -19,14 +21,24 @@ import java.awt.Color
 
 class EditorHighlighter(private val project: Project) {
 
+    private val log = Logger.getInstance(EditorHighlighter::class.java)
+
     private var currentHighlighters: List<RangeHighlighter> = emptyList()
     private var currentEditor: Editor? = null
 
     fun highlightHunk(filePath: String, newStart: Int, newLines: Int) {
         clearHighlight()
 
-        val virtualFile = findFile(filePath) ?: return
-        val editor = openOrFocus(virtualFile) ?: return
+        val virtualFile = findFile(filePath)
+        if (virtualFile == null) {
+            log.debug("Codewalker: file not found in project: $filePath (basePath=${project.basePath})")
+            return
+        }
+        val editor = openOrFocus(virtualFile)
+        if (editor == null) {
+            log.debug("Codewalker: openTextEditor returned null for ${virtualFile.path}")
+            return
+        }
 
         currentEditor = editor
 
@@ -65,11 +77,16 @@ class EditorHighlighter(private val project: Project) {
     }
 
     private fun findFile(filePath: String): VirtualFile? {
+        val basePath = project.basePath
+        if (basePath != null) {
+            val direct = LocalFileSystem.getInstance().findFileByPath("$basePath/$filePath")
+            if (direct != null) return direct
+        }
         val fileName = filePath.substringAfterLast('/')
         return ReadAction.compute<VirtualFile?, RuntimeException> {
             FilenameIndex.getVirtualFilesByName(
                 fileName,
-                GlobalSearchScope.projectScope(project)
+                GlobalSearchScope.allScope(project)
             ).firstOrNull { it.path.endsWith(filePath) }
         }
     }

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -1,5 +1,6 @@
 package com.snootbeestci.codewalker.editor
 
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
@@ -65,10 +66,12 @@ class EditorHighlighter(private val project: Project) {
 
     private fun findFile(filePath: String): VirtualFile? {
         val fileName = filePath.substringAfterLast('/')
-        return FilenameIndex.getVirtualFilesByName(
-            fileName,
-            GlobalSearchScope.projectScope(project)
-        ).firstOrNull { it.path.endsWith(filePath) }
+        return ReadAction.compute<VirtualFile?, RuntimeException> {
+            FilenameIndex.getVirtualFilesByName(
+                fileName,
+                GlobalSearchScope.projectScope(project)
+            ).firstOrNull { it.path.endsWith(filePath) }
+        }
     }
 
     private fun openOrFocus(file: VirtualFile): Editor? {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -15,7 +15,7 @@ class CodewalkerPanel(project: Project) {
     private val disconnectedPanel = DisconnectedPanel()
     internal val idlePanel = IdlePanel()
     internal val loadingPanel = LoadingPanel()
-    private val sessionPanel = SessionPanel()
+    private val sessionPanel = SessionPanel(project)
     private val controller = ReviewSessionController(this)
 
     init {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -3,6 +3,7 @@ package com.snootbeestci.codewalker.toolwindow
 import codewalker.v1.Codewalker.EdgeLabel
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.Codewalker.StepComplete
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
 import com.snootbeestci.codewalker.editor.EditorHighlighter
@@ -29,6 +30,7 @@ class SessionPanel(private val project: Project) {
 
     val root: JPanel = JPanel(GridBagLayout())
 
+    private val log = Logger.getInstance(SessionPanel::class.java)
     private val highlighter = EditorHighlighter(project)
 
     private val titleLabel = JLabel("Codewalker")
@@ -205,8 +207,11 @@ class SessionPanel(private val project: Project) {
         stepListModel.clear()
         val grouped = LinkedHashMap<String, MutableList<Step>>()
         for (step in steps) {
-            val path = step.hunkSpan.filePath.ifEmpty { "(unknown)" }
-            grouped.getOrPut(path) { mutableListOf() }.add(step)
+            val path = step.hunkSpan.filePath
+            if (path.isEmpty()) {
+                log.warn("Hunk step has empty filePath: id=${step.id}")
+            }
+            grouped.getOrPut(path.ifEmpty { "(unknown)" }) { mutableListOf() }.add(step)
         }
         for ((path, fileSteps) in grouped) {
             stepListModel.addElement(StepListItem.Header(path))

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -3,7 +3,9 @@ package com.snootbeestci.codewalker.toolwindow
 import codewalker.v1.Codewalker.EdgeLabel
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.Codewalker.StepComplete
+import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
+import com.snootbeestci.codewalker.editor.EditorHighlighter
 import com.snootbeestci.codewalker.session.NavigationController
 import com.snootbeestci.codewalker.session.ReviewSessionController
 import java.awt.BorderLayout
@@ -23,9 +25,11 @@ import javax.swing.JTextPane
 import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
 
-class SessionPanel {
+class SessionPanel(private val project: Project) {
 
     val root: JPanel = JPanel(GridBagLayout())
+
+    private val highlighter = EditorHighlighter(project)
 
     private val titleLabel = JLabel("Codewalker")
     private val languageLabel = JLabel(" ")
@@ -150,6 +154,7 @@ class SessionPanel {
     fun dispose() {
         navigationController?.dispose()
         navigationController = null
+        highlighter.dispose()
     }
 
     fun clearNarration() {
@@ -171,6 +176,12 @@ class SessionPanel {
         }
         forwardButton.isEnabled = hasForward
         backButton.isEnabled = complete.breadcrumbList.size > 1
+
+        val step = controller?.steps?.firstOrNull { it.id == complete.stepId }
+        if (step != null && step.hasHunkSpan()) {
+            val span = step.hunkSpan
+            highlighter.highlightHunk(span.filePath, span.newStart, span.newLines)
+        }
     }
 
     private fun updateBreadcrumb(crumbs: List<String>) {


### PR DESCRIPTION
## Summary

Make review sessions feel native to the IDE by opening the file from the
diff in the editor and highlighting the current hunk's lines as the user
navigates through steps.

### Commits

1. **`feat: highlight current step's lines in IDE editor`**
   - New `EditorHighlighter` (`src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt`):
     resolves `HunkSpan.filePath` against the project, opens/focuses the
     file with `FileEditorManager.openTextEditor`, applies a
     `RangeHighlighter` over `newStart`..`newStart + newLines - 1` with a
     theme-aware `JBColor` background, and scrolls the range to centre.
     Files not found in the project are silently skipped.
   - `SessionPanel` now takes a `Project`, owns an `EditorHighlighter`,
     calls `highlightHunk(...)` on each `onStepComplete` for steps with a
     hunk span, and disposes the highlighter on panel disposal (which
     clears any remaining range highlighters).
   - `CodewalkerPanel` passes its `project` through to `SessionPanel`.
   - Briefing updated with a Kotlin development rule covering
     `FileEditorManager.openTextEditor`, `addRangeHighlighter`, and the
     requirement to dispose `RangeHighlighter`s.

2. **`fix: wrap FilenameIndex lookup in a read action`**
   - `FilenameIndex.getVirtualFilesByName` requires read access; calling
     it directly from the EDT during `onStepComplete` threw
     `"Read access is allowed from inside read-action only"`. The lookup
     in `EditorHighlighter.findFile` is now wrapped in
     `ReadAction.compute { ... }`.

3. **`docs: note read-action requirement for index lookups`**
   - Adds a Kotlin development rule to the briefing reminding future
     sessions that index/PSI access from the EDT or coroutines must be
     wrapped in `ReadAction.compute { ... }`.

4. **`fix: resolve hunk file via project.basePath, log when missing`**
   - The previous lookup used `FilenameIndex` with `projectScope`, which
     only matches files in indexed content roots and silently returned
     null for many real cases (no editor would open). The PR file path
     is relative to the repo root, so resolve it directly through
     `LocalFileSystem` against `project.basePath` first, and fall back
     to a broader `allScope` `FilenameIndex` search.
   - Adds debug logging for both lookup failures and `openTextEditor`
     returning null, so future "no editor opens" reports can be
     diagnosed from the IDE log.

5. **`fix(toolwindow): warn when hunk step has empty filePath`**
   - `SessionPanel.populateStepList` previously grouped hunk steps with
     an empty `filePath` silently under "(unknown)". This indicates a
     backend bug worth surfacing — now logs a `warn` line including the
     step id while still grouping under "(unknown)" so the UI continues
     to render.

## Notes

- `./gradlew check` could not run in the sandbox: the JetBrains and
  JitPack repositories return HTTP 403 here, so resolving the
  `idea:ideaIC:2025.1` platform dependency fails before any compilation.
  The check should be run locally / in CI before merging.

## Test plan

- [ ] `./gradlew check` passes
- [ ] `./gradlew runIde`, open a PR against a project that's checked out
      locally, navigate through hunks — editor opens the right file,
      scrolls to centre, and the hunk lines are highlighted (no
      threading exception in the log)
- [ ] Navigating to another step clears the previous highlight before
      applying the new one
- [ ] Closing the session / disposing the tool window clears all
      Codewalker highlights
- [ ] Open a PR for a repo not checked out locally — no error dialog,
      navigation still works (just no editor highlight); IDE log shows
      a `Codewalker: file not found in project: ...` debug line
- [ ] Highlight colour is readable in both light and dark IDE themes
- [ ] If a hunk step arrives with an empty `filePath`, the IDE log
      contains a `Hunk step has empty filePath: id=...` warn line and
      the step still appears under "(unknown)"

https://claude.ai/code/session_01D7xwVvc7yG5SeVMuGuU6h9