### PR TITLE
fix(editor): apply highlight on navigation start, not on narration complete

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -141,6 +141,9 @@ When opening a review session the plugin resolves a forge token as follows:
 - `./gradlew buildPlugin` — produces a distributable `.zip`
 - `./gradlew check` — runs tests and verifications
 - Always run `./gradlew check` before submitting a PR
+- All non-trivial logic must ship with unit tests in the same PR — not as a follow-up
+- Use JUnit 5 (`org.junit.jupiter.api`) for new tests
+- Test files mirror the package structure under `src/test/kotlin/`
 
 ### Briefing and README
 - If your change introduces a new architectural decision, append it here

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -1,5 +1,6 @@
 package com.snootbeestci.codewalker.editor
 
+import codewalker.v1.Codewalker.HunkSpan
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -26,12 +27,12 @@ class EditorHighlighter(private val project: Project) {
     private var currentHighlighters: List<RangeHighlighter> = emptyList()
     private var currentEditor: Editor? = null
 
-    fun highlightHunk(filePath: String, newStart: Int, newLines: Int) {
+    fun highlightHunk(span: HunkSpan) {
         clearHighlight()
 
-        val virtualFile = findFile(filePath)
+        val virtualFile = findFile(span.filePath)
         if (virtualFile == null) {
-            log.debug("Codewalker: file not found in project: $filePath (basePath=${project.basePath})")
+            log.debug("Codewalker: file not found in project: ${span.filePath} (basePath=${project.basePath})")
             return
         }
         val editor = openOrFocus(virtualFile)
@@ -43,9 +44,7 @@ class EditorHighlighter(private val project: Project) {
         currentEditor = editor
 
         val document = editor.document
-        val startOffset = document.getLineStartOffset((newStart - 1).coerceAtLeast(0))
-        val endLine = (newStart + newLines - 2).coerceAtMost(document.lineCount - 1)
-        val endOffset = document.getLineEndOffset(endLine)
+        val ranges = computeAddedLineRanges(span.rawDiff, span.newStart)
 
         val attributes = TextAttributes().apply {
             backgroundColor = JBColor(
@@ -54,18 +53,23 @@ class EditorHighlighter(private val project: Project) {
             )
         }
 
-        val highlighter = editor.markupModel.addRangeHighlighter(
-            startOffset,
-            endOffset,
-            HighlighterLayer.SELECTION - 1,
-            attributes,
-            HighlighterTargetArea.EXACT_RANGE
-        )
+        currentHighlighters = ranges.map { range ->
+            val startLine = (range.first - 1).coerceAtLeast(0)
+            val endLine = (range.last - 1).coerceAtMost(document.lineCount - 1)
+            val startOffset = document.getLineStartOffset(startLine)
+            val endOffset = document.getLineEndOffset(endLine)
+            editor.markupModel.addRangeHighlighter(
+                startOffset,
+                endOffset,
+                HighlighterLayer.SELECTION - 1,
+                attributes,
+                HighlighterTargetArea.EXACT_RANGE
+            )
+        }
 
-        currentHighlighters = listOf(highlighter)
-
+        val scrollLine = (ranges.firstOrNull()?.first ?: span.newStart) - 1
         editor.scrollingModel.scrollTo(
-            LogicalPosition(newStart - 1, 0),
+            LogicalPosition(scrollLine.coerceAtLeast(0), 0),
             ScrollType.CENTER
         )
     }
@@ -99,5 +103,48 @@ class EditorHighlighter(private val project: Project) {
 
     fun dispose() {
         clearHighlight()
+    }
+
+    companion object {
+        // Walks a unified-diff hunk body and returns line ranges in the new file
+        // covering only added (`+`) lines. Context (` `) and removed (`-`) lines
+        // are skipped so the highlight tracks just the change.
+        internal fun computeAddedLineRanges(rawDiff: String, newStart: Int): List<IntRange> {
+            if (rawDiff.isEmpty()) return emptyList()
+            val ranges = mutableListOf<IntRange>()
+            var currentNewLine = newStart
+            var rangeStart: Int? = null
+
+            for (line in rawDiff.lineSequence()) {
+                if (line.startsWith("@@") || line.startsWith("+++") || line.startsWith("---")) {
+                    continue
+                }
+                when {
+                    line.startsWith("+") -> {
+                        if (rangeStart == null) rangeStart = currentNewLine
+                        currentNewLine++
+                    }
+                    line.startsWith("-") -> {
+                        // present only in old file; do not advance new-file counter
+                    }
+                    line.startsWith("\\") -> {
+                        // "\ No newline at end of file" marker
+                    }
+                    else -> {
+                        // context line (" " prefix or empty line within hunk body)
+                        if (rangeStart != null) {
+                            ranges.add(rangeStart..(currentNewLine - 1))
+                            rangeStart = null
+                        }
+                        currentNewLine++
+                    }
+                }
+            }
+
+            if (rangeStart != null) {
+                ranges.add(rangeStart..(currentNewLine - 1))
+            }
+            return ranges
+        }
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
@@ -2,6 +2,7 @@ package com.snootbeestci.codewalker.session
 
 import codewalker.v1.Codewalker.NavigateRequest
 import codewalker.v1.Codewalker.SimpleDirection
+import codewalker.v1.Codewalker.Step
 import codewalker.v1.navigateRequest
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
 import com.snootbeestci.codewalker.toolwindow.SessionPanel
@@ -21,20 +22,42 @@ class NavigationController(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var navigateJob: Job? = null
 
-    fun navigateForward() = navigate(navigateRequest {
-        sessionId = controller.sessionId!!
-        direction = SimpleDirection.SIMPLE_DIRECTION_FORWARD
-    })
+    fun navigateForward() {
+        val nextStep = findNextStep() ?: return
+        panel.applyHighlightFor(nextStep)
+        navigate(navigateRequest {
+            sessionId = controller.sessionId!!
+            direction = SimpleDirection.SIMPLE_DIRECTION_FORWARD
+        })
+    }
 
-    fun navigateBack() = navigate(navigateRequest {
-        sessionId = controller.sessionId!!
-        direction = SimpleDirection.SIMPLE_DIRECTION_BACK
-    })
+    fun navigateBack() {
+        val previousStep = findPreviousStep() ?: return
+        panel.applyHighlightFor(previousStep)
+        navigate(navigateRequest {
+            sessionId = controller.sessionId!!
+            direction = SimpleDirection.SIMPLE_DIRECTION_BACK
+        })
+    }
 
-    fun navigateTo(stepId: String) = navigate(navigateRequest {
-        sessionId = controller.sessionId!!
-        this.stepId = stepId
-    })
+    fun navigateTo(stepId: String) {
+        val step = controller.steps.firstOrNull { it.id == stepId } ?: return
+        panel.applyHighlightFor(step)
+        navigate(navigateRequest {
+            sessionId = controller.sessionId!!
+            this.stepId = stepId
+        })
+    }
+
+    private fun findNextStep(): Step? {
+        val currentIdx = controller.steps.indexOfFirst { it.id == controller.currentStepId }
+        return controller.steps.getOrNull(currentIdx + 1)
+    }
+
+    private fun findPreviousStep(): Step? {
+        val currentIdx = controller.steps.indexOfFirst { it.id == controller.currentStepId }
+        return controller.steps.getOrNull(currentIdx - 1)
+    }
 
     private fun navigate(request: NavigateRequest) {
         navigateJob?.cancel()

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -178,9 +178,10 @@ class SessionPanel(private val project: Project) {
         }
         forwardButton.isEnabled = hasForward
         backButton.isEnabled = complete.breadcrumbList.size > 1
+    }
 
-        val step = controller?.steps?.firstOrNull { it.id == complete.stepId }
-        if (step != null && step.hasHunkSpan()) {
+    fun applyHighlightFor(step: Step) {
+        if (step.hasHunkSpan()) {
             val span = step.hunkSpan
             highlighter.highlightHunk(span.filePath, span.newStart, span.newLines)
         }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -182,8 +182,7 @@ class SessionPanel(private val project: Project) {
 
     fun applyHighlightFor(step: Step) {
         if (step.hasHunkSpan()) {
-            val span = step.hunkSpan
-            highlighter.highlightHunk(span.filePath, span.newStart, span.newLines)
+            highlighter.highlightHunk(step.hunkSpan)
         }
     }
 

--- a/src/test/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighterTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighterTest.kt
@@ -1,0 +1,134 @@
+package com.snootbeestci.codewalker.editor
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EditorHighlighterTest {
+
+    @Test
+    fun `single contiguous block of added lines`() {
+        val diff = """
+            @@ -10,3 +10,5 @@
+             context line one
+            +added line one
+            +added line two
+             context line two
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(11..12), ranges)
+    }
+
+    @Test
+    fun `multiple non-contiguous blocks separated by context`() {
+        val diff = """
+            @@ -10,7 +10,9 @@
+             context one
+            +added one
+             context two
+            +added two
+            +added three
+             context three
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(11..11, 13..14), ranges)
+    }
+
+    @Test
+    fun `pure deletion produces no ranges`() {
+        val diff = """
+            @@ -10,3 +10,1 @@
+             context
+            -removed one
+            -removed two
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(emptyList<IntRange>(), ranges)
+    }
+
+    @Test
+    fun `deletions interleaved with additions`() {
+        val diff = """
+            @@ -10,4 +10,4 @@
+             context
+            -removed
+            +added
+             context
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(11..11), ranges)
+    }
+
+    @Test
+    fun `no newline at end of file marker is ignored`() {
+        val diff = """
+            @@ -10,2 +10,3 @@
+             context
+            +added one
+            +added two
+            \ No newline at end of file
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(11..12), ranges)
+    }
+
+    @Test
+    fun `empty diff returns empty list`() {
+        val ranges = EditorHighlighter.computeAddedLineRanges("", 10)
+
+        assertEquals(emptyList<IntRange>(), ranges)
+    }
+
+    @Test
+    fun `addition at the very start of the hunk`() {
+        val diff = """
+            @@ -10,3 +10,4 @@
+            +added at start
+             context one
+             context two
+             context three
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(10..10), ranges)
+    }
+
+    @Test
+    fun `addition at the very end of the hunk`() {
+        val diff = """
+            @@ -10,3 +10,4 @@
+             context one
+             context two
+             context three
+            +added at end
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(13..13), ranges)
+    }
+
+    @Test
+    fun `hunk header line is skipped`() {
+        val diff = """
+            @@ -10,3 +10,4 @@
+             context
+            +added
+             context
+        """.trimIndent()
+
+        val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
+
+        assertEquals(listOf(11..11), ranges)
+    }
+}


### PR DESCRIPTION
Closes #21.

## Summary

Three related changes to the editor highlight that fires during a review session:

1. **Apply highlight on navigation start, not on narration complete.**
   The highlight previously only appeared once `onStepComplete` fired — i.e. after the narration stream finished, often 10+ seconds later. The target step is known the moment `Navigate` is called, so the highlight can be applied synchronously up front.

2. **Highlight only added lines, not surrounding context.**
   `HunkSpan.new_start` / `new_lines` covers the whole hunk window including the context the reviewer can already see, which made the actual change harder to spot. The plugin now parses `HunkSpan.raw_diff` (unified diff) and produces one highlighter per contiguous run of `+` lines, skipping ` ` context and `-` removed lines.

3. **Unit tests for the diff parser.**
   `computeAddedLineRanges` is pure logic, so it gets full unit-test coverage in this PR.

## Changes

- `NavigationController` (`navigateForward` / `navigateBack` / `navigateTo`) resolves the target step from `controller.steps` and calls `panel.applyHighlightFor(step)` before launching the gRPC stream. Helpers `findNextStep` / `findPreviousStep` look up the next/previous step based on `currentStepId`.
- `SessionPanel.applyHighlightFor(step: Step)` exposed; the redundant hunk-highlight call has been removed from `onStepComplete`.
- `EditorHighlighter.highlightHunk` now takes a `HunkSpan` and calls a new `computeAddedLineRanges(rawDiff, newStart)` helper that walks the unified-diff body, advancing the new-file line counter on `+` and ` ` lines and skipping `-` lines, to produce ranges covering only added lines. One `RangeHighlighter` is created per range; all are tracked together so `clearHighlight()` disposes them collectively. Scrolls to the first added line (or `new_start` if the hunk is purely deletions).
- `EditorHighlighterTest` covers single/multiple/contiguous/non-contiguous additions, pure deletions, deletions interleaved with additions, the `\ No newline at end of file` marker, empty input, and additions at the start/end of the hunk.
- `codewalker-intellij-briefing.md` updated under Build rules to require unit tests for non-trivial logic in the same PR, with JUnit 5 under `src/test/kotlin/` mirroring the package structure.

The narration stream still flows into the panel after the highlight is in place.

## Verification

- `./gradlew check` could not be run locally — the sandbox blocks JetBrains' Maven repositories (403 Forbidden on `download.jetbrains.com` / `cache-redirector.jetbrains.com`), so the IntelliJ Platform dependency cannot be resolved. CI on a network-enabled runner should validate the build and run the new test class.
- Each test case was hand-traced against the parser implementation and produces the asserted output.

## Test plan

- [ ] `./gradlew check` passes on CI (runs `EditorHighlighterTest`)
- [ ] Open a review session, click Forward → editor highlight appears immediately, before any narration tokens stream
- [ ] Click Back → highlight updates immediately to the previous hunk
- [ ] Click a step in the list → highlight updates immediately to that hunk
- [ ] Highlight covers only the `+` lines of the hunk; surrounding context lines are not highlighted
- [ ] A hunk with multiple separate `+` runs (split by context) shows multiple highlight bands
- [ ] A hunk that is pure deletion produces no highlight but still scrolls to the location
- [ ] Narration still streams correctly into the panel after the highlight is applied
- [ ] No stale highlights remain after navigating between hunks
