### PR TITLE
Render structured StepSummary table in SessionPanel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.3.1") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.3.2") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.3.2") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.3.10") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }
-    implementation("io.grpc:grpc-okhttp:1.60.0") {
+    implementation("io.grpc:grpc-okhttp:1.68.1") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.2.0") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.3.1") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -84,6 +84,23 @@ Registered as a right-side tool window. Four states managed via `CardLayout`:
 | LOADING | `OpenReviewSession` in progress |
 | SESSION | Session open, narration active |
 
+### Session body layout
+
+Inside the SESSION card, the body is split horizontally:
+
+- **West**: step list (grouped by file path)
+- **Centre**: a vertical column of
+  - `SummaryTable` — fixed two-column key/value list rendering the eight
+    `StepSummary` fields. Always visible. Empty/unset fields render as `—`
+    so the layout never collapses.
+  - `CollapsibleSection` wrapping the streamed narration `JTextPane`.
+    Collapsed by default — clicking the header toggles visibility.
+
+`SessionPanel.onStepComplete` calls `summaryTable.update(complete.summary)`
+when `complete.hasSummary()` is true, otherwise passes `null` (which clears
+the table). `SessionPanel.clearNarration` clears both the narration pane
+and the summary table.
+
 ---
 
 ## Session model

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CollapsibleSection.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CollapsibleSection.kt
@@ -1,0 +1,56 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import com.intellij.icons.AllIcons
+import com.intellij.ui.components.JBLabel
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Cursor
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.BorderFactory
+import javax.swing.JPanel
+
+class CollapsibleSection(title: String, private val content: Component, expanded: Boolean = false) {
+
+    val root: JPanel = JPanel(BorderLayout())
+
+    private val arrowLabel = JBLabel(if (expanded) AllIcons.General.ArrowDown else AllIcons.General.ArrowRight)
+    private val titleLabel = JBLabel(title)
+    private var isExpanded = expanded
+
+    init {
+        val header = JPanel(BorderLayout()).apply {
+            border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
+            add(arrowLabel, BorderLayout.WEST)
+            add(titleLabel, BorderLayout.CENTER)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    toggle()
+                }
+            })
+        }
+
+        root.add(header, BorderLayout.NORTH)
+        root.add(content, BorderLayout.CENTER)
+        content.isVisible = expanded
+    }
+
+    private fun toggle() {
+        isExpanded = !isExpanded
+        content.isVisible = isExpanded
+        arrowLabel.icon = if (isExpanded) AllIcons.General.ArrowDown else AllIcons.General.ArrowRight
+        root.revalidate()
+        root.repaint()
+    }
+
+    fun expand() {
+        if (!isExpanded) toggle()
+    }
+
+    fun collapse() {
+        if (isExpanded) toggle()
+    }
+
+    fun isExpanded(): Boolean = isExpanded
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -17,6 +17,7 @@ import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.Insets
 import javax.swing.BorderFactory
+import javax.swing.BoxLayout
 import javax.swing.DefaultListModel
 import javax.swing.JButton
 import javax.swing.JLabel
@@ -45,6 +46,16 @@ class SessionPanel(private val project: Project) {
     private val narrationPane = JTextPane().apply {
         isEditable = false
     }
+    private val summaryTable = SummaryTable()
+    private val narrationScroll = JBScrollPane(narrationPane).apply {
+        preferredSize = Dimension(360, 180)
+        minimumSize = Dimension(200, 120)
+    }
+    private val narrationCollapsible = CollapsibleSection(
+        title = "Detailed narration",
+        content = narrationScroll,
+        expanded = false
+    )
     private val backButton = JButton("← Back").apply { isEnabled = false }
     private val forwardButton = JButton("Forward →").apply { isEnabled = false }
 
@@ -83,11 +94,6 @@ class SessionPanel(private val project: Project) {
             minimumSize = Dimension(160, 120)
         }
 
-        val narrationScroll = JBScrollPane(narrationPane).apply {
-            preferredSize = Dimension(360, 200)
-            minimumSize = Dimension(200, 120)
-        }
-
         val navBar = JPanel(GridBagLayout()).apply {
             border = BorderFactory.createEmptyBorder(4, 8, 6, 8)
             add(backButton, GridBagConstraints().apply {
@@ -102,9 +108,15 @@ class SessionPanel(private val project: Project) {
             })
         }
 
+        val bodyColumn = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            add(summaryTable.root)
+            add(narrationCollapsible.root)
+        }
+
         val body = JPanel(BorderLayout()).apply {
             add(stepListScroll, BorderLayout.WEST)
-            add(narrationScroll, BorderLayout.CENTER)
+            add(bodyColumn, BorderLayout.CENTER)
         }
 
         fun row(component: Component, gridy: Int, weighty: Double, fill: Int) {
@@ -161,6 +173,7 @@ class SessionPanel(private val project: Project) {
 
     fun clearNarration() {
         narrationPane.text = ""
+        summaryTable.clear()
     }
 
     fun appendNarrationToken(text: String) {
@@ -173,6 +186,7 @@ class SessionPanel(private val project: Project) {
         controller?.currentStepId = complete.stepId
         updateBreadcrumb(complete.breadcrumbList)
         updateStepHighlight(complete.stepId)
+        summaryTable.update(if (complete.hasSummary()) complete.summary else null)
         val hasForward = complete.availableEdgesList.any {
             it.label == EdgeLabel.EDGE_LABEL_NEXT && it.navigable
         }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTable.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTable.kt
@@ -1,0 +1,72 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import codewalker.v1.Codewalker.StepSummary
+import com.intellij.ui.JBColor
+import java.awt.Font
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class SummaryTable {
+
+    val root: JPanel = JPanel(GridBagLayout())
+
+    private val rows: List<Pair<String, JLabel>> = listOf(
+        "Breaking" to JLabel(EMPTY_VALUE),
+        "Risk" to JLabel(EMPTY_VALUE),
+        "What changed" to JLabel(EMPTY_VALUE),
+        "Side effects" to JLabel(EMPTY_VALUE),
+        "Tests" to JLabel(EMPTY_VALUE),
+        "Reviewer focus" to JLabel(EMPTY_VALUE),
+        "Suggestion" to JLabel(EMPTY_VALUE),
+        "Confidence" to JLabel(EMPTY_VALUE),
+    )
+
+    init {
+        rows.forEachIndexed { index, (label, valueLabel) ->
+            val keyLabel = JLabel(label).apply {
+                font = font.deriveFont(Font.BOLD)
+                foreground = JBColor.GRAY
+            }
+            root.add(keyLabel, GridBagConstraints().apply {
+                gridx = 0; gridy = index
+                anchor = GridBagConstraints.NORTHWEST
+                insets = Insets(2, 8, 2, 12)
+            })
+            root.add(valueLabel, GridBagConstraints().apply {
+                gridx = 1; gridy = index
+                weightx = 1.0
+                fill = GridBagConstraints.HORIZONTAL
+                anchor = GridBagConstraints.NORTHWEST
+                insets = Insets(2, 0, 2, 8)
+            })
+        }
+    }
+
+    fun update(summary: StepSummary?) {
+        if (summary == null) {
+            clear()
+            return
+        }
+        rows[0].second.text = summary.breaking.ifEmpty { EMPTY_VALUE }
+        rows[1].second.text = summary.risk.ifEmpty { EMPTY_VALUE }
+        rows[2].second.text = summary.whatChanged.ifEmpty { EMPTY_VALUE }
+        rows[3].second.text = summary.sideEffects.ifEmpty { EMPTY_VALUE }
+        rows[4].second.text = summary.tests.ifEmpty { EMPTY_VALUE }
+        rows[5].second.text = summary.reviewerFocus.ifEmpty { EMPTY_VALUE }
+        rows[6].second.text = summary.suggestion.ifEmpty { EMPTY_VALUE }
+        rows[7].second.text = summary.confidence.ifEmpty { EMPTY_VALUE }
+    }
+
+    fun clear() {
+        rows.forEach { (_, label) -> label.text = EMPTY_VALUE }
+    }
+
+    fun valueLabelAt(index: Int): JLabel = rows[index].second
+
+    companion object {
+        const val EMPTY_VALUE: String = "—"
+    }
+}

--- a/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/CollapsibleSectionTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/CollapsibleSectionTest.kt
@@ -1,0 +1,73 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import javax.swing.JLabel
+
+class CollapsibleSectionTest {
+
+    @Test
+    fun `default collapsed hides content`() {
+        val content = JLabel("body")
+
+        val section = CollapsibleSection("Detail", content)
+
+        assertFalse(section.isExpanded())
+        assertFalse(content.isVisible)
+    }
+
+    @Test
+    fun `expanded=true shows content`() {
+        val content = JLabel("body")
+
+        val section = CollapsibleSection("Detail", content, expanded = true)
+
+        assertTrue(section.isExpanded())
+        assertTrue(content.isVisible)
+    }
+
+    @Test
+    fun `expand on a collapsed section shows content`() {
+        val content = JLabel("body")
+        val section = CollapsibleSection("Detail", content)
+
+        section.expand()
+
+        assertTrue(section.isExpanded())
+        assertTrue(content.isVisible)
+    }
+
+    @Test
+    fun `collapse on an expanded section hides content`() {
+        val content = JLabel("body")
+        val section = CollapsibleSection("Detail", content, expanded = true)
+
+        section.collapse()
+
+        assertFalse(section.isExpanded())
+        assertFalse(content.isVisible)
+    }
+
+    @Test
+    fun `repeated expand stays expanded`() {
+        val content = JLabel("body")
+        val section = CollapsibleSection("Detail", content, expanded = true)
+
+        section.expand()
+
+        assertTrue(section.isExpanded())
+        assertTrue(content.isVisible)
+    }
+
+    @Test
+    fun `repeated collapse stays collapsed`() {
+        val content = JLabel("body")
+        val section = CollapsibleSection("Detail", content)
+
+        section.collapse()
+
+        assertFalse(section.isExpanded())
+        assertFalse(content.isVisible)
+    }
+}

--- a/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTableTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTableTest.kt
@@ -1,0 +1,97 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import codewalker.v1.Codewalker.StepSummary
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SummaryTableTest {
+
+    @Test
+    fun `initial state shows em-dashes for every row`() {
+        val table = SummaryTable()
+
+        repeat(8) { i ->
+            assertEquals(SummaryTable.EMPTY_VALUE, table.valueLabelAt(i).text)
+        }
+    }
+
+    @Test
+    fun `update with all fields populated maps each field to the correct row`() {
+        val table = SummaryTable()
+        val summary = StepSummary.newBuilder()
+            .setBreaking("No")
+            .setRisk("Low — clean refactor")
+            .setWhatChanged("Renames helper function")
+            .setSideEffects("None")
+            .setTests("Modified")
+            .setReviewerFocus("Verify rename consistency")
+            .setSuggestion("Consider deprecation alias")
+            .setConfidence("High")
+            .build()
+
+        table.update(summary)
+
+        assertEquals("No", table.valueLabelAt(0).text)
+        assertEquals("Low — clean refactor", table.valueLabelAt(1).text)
+        assertEquals("Renames helper function", table.valueLabelAt(2).text)
+        assertEquals("None", table.valueLabelAt(3).text)
+        assertEquals("Modified", table.valueLabelAt(4).text)
+        assertEquals("Verify rename consistency", table.valueLabelAt(5).text)
+        assertEquals("Consider deprecation alias", table.valueLabelAt(6).text)
+        assertEquals("High", table.valueLabelAt(7).text)
+    }
+
+    @Test
+    fun `empty fields render as em-dash`() {
+        val table = SummaryTable()
+        val summary = StepSummary.newBuilder()
+            .setBreaking("Yes")
+            .setRisk("")
+            .setWhatChanged("Adds retry logic")
+            .build()
+
+        table.update(summary)
+
+        assertEquals("Yes", table.valueLabelAt(0).text)
+        assertEquals(SummaryTable.EMPTY_VALUE, table.valueLabelAt(1).text)
+        assertEquals("Adds retry logic", table.valueLabelAt(2).text)
+        assertEquals(SummaryTable.EMPTY_VALUE, table.valueLabelAt(3).text)
+        assertEquals(SummaryTable.EMPTY_VALUE, table.valueLabelAt(7).text)
+    }
+
+    @Test
+    fun `update with null clears all rows`() {
+        val table = SummaryTable()
+        table.update(
+            StepSummary.newBuilder()
+                .setBreaking("Yes")
+                .setConfidence("High")
+                .build()
+        )
+
+        table.update(null)
+
+        repeat(8) { i ->
+            assertEquals(SummaryTable.EMPTY_VALUE, table.valueLabelAt(i).text)
+        }
+    }
+
+    @Test
+    fun `clear resets all rows after a populated update`() {
+        val table = SummaryTable()
+        table.update(
+            StepSummary.newBuilder()
+                .setBreaking("No")
+                .setRisk("Medium")
+                .setWhatChanged("Refactors auth flow")
+                .setConfidence("High")
+                .build()
+        )
+
+        table.clear()
+
+        repeat(8) { i ->
+            assertEquals(SummaryTable.EMPTY_VALUE, table.valueLabelAt(i).text)
+        }
+    }
+}


### PR DESCRIPTION
Closes #27.

## Summary

The backend now returns a structured `StepSummary` (eight key/value fields) on `StepComplete` for review session steps. This PR renders that summary as a fixed two-column table above the narration, and demotes the streaming narration into a collapsible section that's hidden by default.

## Commits

1. **build: bump codewalker-proto to v0.3.1 for StepSummary stub** — Initial bump from `v0.2.0`. Required because v0.2.0 doesn't expose `StepSummary`.
2. **feat(toolwindow): add SummaryTable and CollapsibleSection components** — New `SummaryTable.kt` renders eight rows (Breaking, Risk, What changed, Side effects, Tests, Reviewer focus, Suggestion, Confidence) in a `GridBagLayout`; empty/unset fields render as `—`. New `CollapsibleSection.kt` is a generic header-toggle wrapper around any `Component`.
3. **test(toolwindow): add unit tests for SummaryTable and CollapsibleSection** — JUnit Jupiter tests covering: initial em-dash state, full-field mapping, empty-string fallback, `update(null)` clearing, `clear()`, and the expand/collapse/idempotency state machine.
4. **feat(toolwindow): render StepSummary table above collapsible narration** — Restructures the body of the SESSION card from `[stepList | narrationScroll]` to `[stepList | bodyColumn]`, where `bodyColumn` is a `BoxLayout` of `[summaryTable, collapsibleNarration]`. `onStepComplete` calls `summaryTable.update(complete.summary)` (or `null` when `hasSummary()` is false). `clearNarration()` also clears the table. Briefing updated with the new layout.
5. **build: bump codewalker-proto to v0.3.2 for working JitPack stubs** — Intermediate bump while the upstream JitPack publication for v0.3.x was being stabilised.
6. **build: bump codewalker-proto to v0.3.10** — First v0.3.x tag whose published JitPack artifact actually contains the new `StepSummary` stubs.
7. **build: align grpc-okhttp to 1.68.1 to match codewalker-proto v0.3.10** — v0.3.10 upgraded its transitive `grpc-protobuf` to 1.68.1, pulling `grpc-api` 1.68.1 onto the classpath. The plugin's pinned `grpc-okhttp:1.60.0` brought in `grpc-core:1.60.0`, which called into the 1.68.1-only `io.grpc.InternalGlobalInterceptors` and threw `NoClassDefFoundError` at runtime channel build. Bumping okhttp keeps every gRPC artifact on the same line.

## Test plan

- [ ] CI runs `./gradlew check` (cannot run locally — sandbox blocks JetBrains repos required for `ideaIC:2025.1`)
- [ ] Manual: `./gradlew runIde`, open a review session, navigate between steps, verify the summary table updates per step and the narration section toggles open/closed
- [ ] Manual: verify the table shows `—` for empty/unset fields rather than collapsing rows
- [ ] Manual: verify `clearNarration` resets the table when binding a new session