### PR TITLE
feat: list open PRs for current project on idle screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ repositories work without a token.
 
 **4. Review a PR**
 
-Open the Codewalker tool window (right side panel), paste a GitHub PR URL,
-and click Open Review.
+Open the Codewalker tool window (right side panel). The plugin lists the
+open pull requests for the current project's GitHub remote — click any
+row to start a review session. If the current project's remote is on a
+host you have signed into via Settings → Tools → Codewalker, the token
+is sent automatically; otherwise public-repo mode is used.
+
+Use the refresh button to refetch the PR list.
 
 ## Development
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     intellijPlatform {
         create(providers.gradleProperty("platformType").get(), providers.gradleProperty("platformVersion").get())
+        bundledPlugin("Git4Idea")
         pluginVerifier()
         zipSigner()
         testFramework(TestFrameworkType.Platform)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.3.10") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.5.0") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -192,6 +192,32 @@ letters `sso`.
 
 ---
 
+## Project entry point
+
+The plugin's idle screen lists open pull requests for the current project's
+GitHub remote, rather than asking the user to paste a URL. The remote is
+detected via Git4Idea (`GitRepositoryManager.getInstance(project)`),
+parsed by `GitHubRemoteResolver` into a canonical (host, owner, repo)
+triple, and the host is normalised via `HostNormalizer.normalize` before
+either keying into `TokenStore` or being sent on the wire.
+
+PRs are fetched via the backend's `ListPullRequests` RPC. The
+`forge_token` is resolved client-side via `TokenStore.getInstance().get(host)` —
+empty for hosts the user has not signed into, which downgrades to
+unauthenticated public access for that fetch.
+
+Refresh is manual via the refresh button — no automatic polling.
+
+Hosts containing "github" are accepted (covers github.com and any GitHub
+Enterprise instance). Other hosts (gitlab, bitbucket, gitea) are
+explicitly rejected with an informational message; they are out of scope
+until the corresponding ForgeHandler exists on the backend.
+
+The plugin declares a `Git4Idea` dependency in `plugin.xml` so the
+JetBrains Git integration is available at runtime in any host IDE.
+
+---
+
 ## Future direction
 
 - **Walkthrough sessions** — explain a file in the open project step by step

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -177,18 +177,22 @@ they do not silently downgrade to unauthenticated mode.
 
 ### 403 / SSO error rendering
 
-`ReviewErrorFormatter.format` converts gRPC errors into user-facing strings.
-For `PERMISSION_DENIED`, the server includes the forge's response body in
-the status description (truncated to ~500 chars).
+`ReviewErrorFormatter.format` converts a server-side error into a
+`FormattedError(message, isAuthFailure)`. Callers use `isAuthFailure`
+directly to decide whether to surface a "Configure tokens" affordance,
+rather than string-matching the message. SSO-marked 403 responses still
+get the `Authorization required:` prefix on the message; the marker
+phrases are listed in the formatter source.
 
-When the body contains specific SSO markers — `SAML enforcement`,
-`SSO authorization` (or `authorisation`), `single sign-on`, `must have
-admin rights`, `configure SSO` — the formatter prepends `Authorization
-required:` so the user knows the token is valid but needs SSO
-authorisation rather than replacement. The markers are phrase-level,
-not bare acronyms, to avoid false positives against bodies that
-mention `associated`, `cross-origin`, or other words containing the
-letters `sso`.
+For `PERMISSION_DENIED`, the server includes the forge's response body in
+the status description (truncated to ~500 chars). When the body contains
+specific SSO markers — `SAML enforcement`, `SSO authorization` (or
+`authorisation`), `single sign-on`, `must have admin rights`,
+`configure SSO` — the formatter prepends `Authorization required:` so
+the user knows the token is valid but needs SSO authorisation rather
+than replacement. The markers are phrase-level, not bare acronyms, to
+avoid false positives against bodies that mention `associated`,
+`cross-origin`, or other words containing the letters `sso`.
 
 ---
 
@@ -215,6 +219,13 @@ until the corresponding ForgeHandler exists on the backend.
 
 The plugin declares a `Git4Idea` dependency in `plugin.xml` so the
 JetBrains Git integration is available at runtime in any host IDE.
+
+URL parsing for git remotes is centralised in
+`GitHubRemoteResolver.parseRemoteUrlResult`, which returns a sealed
+`RemoteParseResult` distinguishing `Ok`, `NonGitHub(host)`,
+`Unparseable`, and `Empty`. The idle panel uses this to render distinct
+messages for each failure mode. There is no separate host-extraction
+path elsewhere in the plugin — host parsing lives in one place.
 
 ---
 
@@ -246,6 +257,11 @@ JetBrains Git integration is available at runtime in any host IDE.
   require a read action — wrap them in `ReadAction.compute { ... }` when
   called from the EDT or a coroutine, otherwise IntelliJ throws
   "Read access is allowed from inside read-action only".
+- UI panels that own a `CoroutineScope` must implement `Disposable` and
+  cancel the scope in `dispose()`. Owning containers register children
+  via `Disposer.register(parent, child)` so cancellation cascades
+  automatically — manual `child.dispose()` calls in a parent's
+  `dispose()` are a code smell.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/src/main/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt
@@ -10,6 +10,17 @@ data class ProjectRepoInfo(
     val repo: String,
 )
 
+/**
+ * Result of parsing a git remote URL into a structured outcome that
+ * distinguishes the cases UI code needs to render differently.
+ */
+sealed class RemoteParseResult {
+    data class Ok(val info: ProjectRepoInfo) : RemoteParseResult()
+    data class NonGitHub(val host: String) : RemoteParseResult()
+    data object Unparseable : RemoteParseResult()
+    data object Empty : RemoteParseResult()
+}
+
 object GitHubRemoteResolver {
 
     fun resolve(project: Project): ProjectRepoInfo? {
@@ -22,31 +33,71 @@ object GitHubRemoteResolver {
         return parseRemoteUrl(url)
     }
 
+    /**
+     * Result-bearing variant. UI callers use this when they need to
+     * distinguish "non-GitHub host" from "unparseable" to render
+     * different error messages.
+     */
+    fun resolveResult(project: Project): RemoteParseResult {
+        val repos = GitRepositoryManager.getInstance(project).repositories
+        val origin = repos.firstNotNullOfOrNull { repo ->
+            repo.remotes.firstOrNull { it.name == "origin" }
+        } ?: return RemoteParseResult.Empty
+
+        val url = origin.firstUrl ?: return RemoteParseResult.Empty
+        return parseRemoteUrlResult(url)
+    }
+
     internal fun parseRemoteUrl(url: String): ProjectRepoInfo? {
+        return when (val r = parseRemoteUrlResult(url)) {
+            is RemoteParseResult.Ok -> r.info
+            else -> null
+        }
+    }
+
+    /**
+     * Single source of truth for all URL → host extraction in the plugin.
+     */
+    internal fun parseRemoteUrlResult(url: String): RemoteParseResult {
         val cleaned = url.trim().removeSuffix("/").let {
             if (it.endsWith(".git")) it.removeSuffix(".git") else it
         }
-        if (cleaned.isEmpty()) return null
+        if (cleaned.isEmpty()) return RemoteParseResult.Empty
 
         val sshShort = Regex("""(?:ssh://)?git@([^:/]+)[:/]([^/]+)/([^/]+)$""")
         sshShort.matchEntire(cleaned)?.let { match ->
             val (rawHost, owner, repo) = match.destructured
-            return makeInfo(rawHost, owner, repo)
+            return classify(rawHost, owner, repo)
         }
 
         val https = Regex("""https?://([^/]+)/([^/]+)/([^/]+)$""")
         https.matchEntire(cleaned)?.let { match ->
             val (rawHost, owner, repo) = match.destructured
-            return makeInfo(rawHost, owner, repo)
+            return classify(rawHost, owner, repo)
         }
 
-        return null
+        val hostOnly = extractHostOnly(cleaned)
+        return if (hostOnly != null) RemoteParseResult.NonGitHub(hostOnly)
+        else RemoteParseResult.Unparseable
     }
 
-    private fun makeInfo(rawHost: String, owner: String, repo: String): ProjectRepoInfo? {
-        if (owner.isEmpty() || repo.isEmpty()) return null
+    private fun classify(rawHost: String, owner: String, repo: String): RemoteParseResult {
+        if (owner.isEmpty() || repo.isEmpty()) return RemoteParseResult.Unparseable
         val host = HostNormalizer.normalize(rawHost)
-        if (!host.contains("github")) return null
-        return ProjectRepoInfo(host, owner, repo)
+        return if (host.contains("github")) {
+            RemoteParseResult.Ok(ProjectRepoInfo(host, owner, repo))
+        } else {
+            RemoteParseResult.NonGitHub(host)
+        }
+    }
+
+    private fun extractHostOnly(cleaned: String): String? {
+        Regex("""(?:ssh://)?git@([^:/]+)[:/].*""").matchEntire(cleaned)?.let {
+            return HostNormalizer.normalize(it.groupValues[1])
+        }
+        Regex("""https?://([^/]+)(?:/.*)?""").matchEntire(cleaned)?.let {
+            return HostNormalizer.normalize(it.groupValues[1])
+        }
+        return null
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt
@@ -1,0 +1,52 @@
+package com.snootbeestci.codewalker.git
+
+import com.intellij.openapi.project.Project
+import com.snootbeestci.codewalker.forge.HostNormalizer
+import git4idea.repo.GitRepositoryManager
+
+data class ProjectRepoInfo(
+    val host: String,
+    val owner: String,
+    val repo: String,
+)
+
+object GitHubRemoteResolver {
+
+    fun resolve(project: Project): ProjectRepoInfo? {
+        val repos = GitRepositoryManager.getInstance(project).repositories
+        val origin = repos.firstNotNullOfOrNull { repo ->
+            repo.remotes.firstOrNull { it.name == "origin" }
+        } ?: return null
+
+        val url = origin.firstUrl ?: return null
+        return parseRemoteUrl(url)
+    }
+
+    internal fun parseRemoteUrl(url: String): ProjectRepoInfo? {
+        val cleaned = url.trim().removeSuffix("/").let {
+            if (it.endsWith(".git")) it.removeSuffix(".git") else it
+        }
+        if (cleaned.isEmpty()) return null
+
+        val sshShort = Regex("""(?:ssh://)?git@([^:/]+)[:/]([^/]+)/([^/]+)$""")
+        sshShort.matchEntire(cleaned)?.let { match ->
+            val (rawHost, owner, repo) = match.destructured
+            return makeInfo(rawHost, owner, repo)
+        }
+
+        val https = Regex("""https?://([^/]+)/([^/]+)/([^/]+)$""")
+        https.matchEntire(cleaned)?.let { match ->
+            val (rawHost, owner, repo) = match.destructured
+            return makeInfo(rawHost, owner, repo)
+        }
+
+        return null
+    }
+
+    private fun makeInfo(rawHost: String, owner: String, repo: String): ProjectRepoInfo? {
+        if (owner.isEmpty() || repo.isEmpty()) return null
+        val host = HostNormalizer.normalize(rawHost)
+        if (!host.contains("github")) return null
+        return ProjectRepoInfo(host, owner, repo)
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerClient.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerClient.kt
@@ -1,7 +1,9 @@
 package com.snootbeestci.codewalker.grpc
 
 import codewalker.v1.CodeWalkerGrpcKt
+import codewalker.v1.Codewalker.ListPullRequestsResponse
 import codewalker.v1.getVersionRequest
+import codewalker.v1.listPullRequestsRequest
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
@@ -53,6 +55,21 @@ class CodewalkerClient : Disposable {
     }
 
     fun getStub(): CodeWalkerGrpcKt.CodeWalkerCoroutineStub? = stub
+
+    suspend fun listPullRequests(
+        host: String,
+        owner: String,
+        repo: String,
+        forgeToken: String,
+    ): ListPullRequestsResponse {
+        val s = stub ?: error("Not connected to backend")
+        return s.listPullRequests(listPullRequestsRequest {
+            this.host = host
+            this.owner = owner
+            this.repo = repo
+            this.forgeToken = forgeToken
+        })
+    }
 
     override fun dispose() { disconnect() }
 

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewErrorFormatter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewErrorFormatter.kt
@@ -4,16 +4,19 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 
 /**
- * Renders a server-side error to a user-facing string, with special handling
- * for `PERMISSION_DENIED` so SSO-required responses are distinguishable from
- * plain "bad token" responses.
+ * Structured render of a server-side error.
  *
- * The server includes the forge's response body (truncated to ~500 chars) in
- * the gRPC status description for 403 responses. GitHub Enterprise SSO
- * responses contain markers like "SAML enforcement" or "single sign-on" —
- * we surface those with an "Authorization required:" prefix so the user
- * knows to authorise the token rather than replace it.
+ * `message` is the user-facing string (with SSO prefix when applicable).
+ * `isAuthFailure` is true for any error that suggests the request failed
+ * because of a missing, expired, or improperly authorised token. Callers
+ * use this to decide whether to surface a "Configure tokens" affordance —
+ * no string-matching required.
  */
+data class FormattedError(
+    val message: String,
+    val isAuthFailure: Boolean,
+)
+
 object ReviewErrorFormatter {
 
     private val ssoMarkers = listOf(
@@ -25,16 +28,33 @@ object ReviewErrorFormatter {
         "configure SSO",
     )
 
-    fun format(e: Throwable): String {
-        if (e is StatusRuntimeException && e.status.code == Status.Code.PERMISSION_DENIED) {
+    fun format(e: Throwable): FormattedError {
+        if (e is StatusRuntimeException) {
+            val code = e.status.code
             val description = e.status.description.orEmpty()
-            val hasSsoMarker = ssoMarkers.any { description.contains(it, ignoreCase = true) }
-            return when {
-                hasSsoMarker -> "Authorization required: $description"
-                description.isNotBlank() -> description
-                else -> "Permission denied"
+            val isAuth = code == Status.Code.PERMISSION_DENIED ||
+                code == Status.Code.UNAUTHENTICATED
+
+            if (code == Status.Code.PERMISSION_DENIED) {
+                val hasSsoMarker = ssoMarkers.any { description.contains(it, ignoreCase = true) }
+                val message = when {
+                    hasSsoMarker -> "Authorization required: $description"
+                    description.isNotBlank() -> description
+                    else -> "Permission denied"
+                }
+                return FormattedError(message, isAuthFailure = true)
             }
+
+            if (code == Status.Code.UNAUTHENTICATED) {
+                val message = description.ifBlank { "Authentication required" }
+                return FormattedError(message, isAuthFailure = true)
+            }
+
+            return FormattedError(
+                e.message ?: "Unknown error",
+                isAuthFailure = isAuth,
+            )
         }
-        return e.message ?: "Unknown error"
+        return FormattedError(e.message ?: "Unknown error", isAuthFailure = false)
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -33,12 +33,12 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
 
     init {
         panel.loadingPanel.cancelButton.addActionListener { cancel() }
-        panel.idlePanel.setOpenReviewAction { openReview() }
+        panel.idlePanel.setPullRequestClickHandler { pr ->
+            openReview(pr.url, panel.idlePanel.getExperienceLevel())
+        }
     }
 
-    private fun openReview() {
-        val url = panel.idlePanel.getUrl()
-        val level = panel.idlePanel.getExperienceLevel()
+    private fun openReview(url: String, level: String) {
         panel.idlePanel.clearError()
         panel.showLoading()
 

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -101,8 +101,8 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                val msg = ReviewErrorFormatter.format(e)
-                withContext(Dispatchers.Main) { panel.showError(msg) }
+                val formatted = ReviewErrorFormatter.format(e)
+                withContext(Dispatchers.Main) { panel.showError(formatted.message) }
             }
         }
     }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -13,7 +13,7 @@ class CodewalkerPanel(project: Project) {
     val root: JPanel = JPanel(CardLayout())
 
     private val disconnectedPanel = DisconnectedPanel()
-    internal val idlePanel = IdlePanel()
+    internal val idlePanel = IdlePanel(project)
     internal val loadingPanel = LoadingPanel()
     private val sessionPanel = SessionPanel(project)
     private val controller = ReviewSessionController(this)
@@ -43,7 +43,10 @@ class CodewalkerPanel(project: Project) {
                 disconnectedPanel.update(state)
                 "DISCONNECTED"
             }
-            CodewalkerClient.ConnectionState.CONNECTED -> "IDLE"
+            CodewalkerClient.ConnectionState.CONNECTED -> {
+                idlePanel.refreshPullRequests()
+                "IDLE"
+            }
         }
         (root.layout as CardLayout).show(root, card)
     }
@@ -63,5 +66,6 @@ class CodewalkerPanel(project: Project) {
         controller.dispose()
         sessionPanel.dispose()
         disconnectedPanel.dispose()
+        idlePanel.dispose()
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -1,14 +1,16 @@
 package com.snootbeestci.codewalker.toolwindow
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
 import com.snootbeestci.codewalker.grpc.ConnectionStateListener
 import com.snootbeestci.codewalker.session.ReviewSessionController
 import java.awt.CardLayout
 import javax.swing.JPanel
 
-class CodewalkerPanel(project: Project) {
+class CodewalkerPanel(project: Project) : Disposable {
 
     val root: JPanel = JPanel(CardLayout())
 
@@ -23,6 +25,8 @@ class CodewalkerPanel(project: Project) {
         root.add(idlePanel.root, "IDLE")
         root.add(loadingPanel.root, "LOADING")
         root.add(sessionPanel.root, "SESSION")
+
+        Disposer.register(this, idlePanel)
 
         project.messageBus.connect(project).subscribe(
             CodewalkerClient.CONNECTION_STATE_TOPIC,
@@ -62,10 +66,9 @@ class CodewalkerPanel(project: Project) {
         (root.layout as CardLayout).show(root, "IDLE")
     }
 
-    fun dispose() {
+    override fun dispose() {
         controller.dispose()
         sessionPanel.dispose()
         disconnectedPanel.dispose()
-        idlePanel.dispose()
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt
@@ -11,7 +11,7 @@ class CodewalkerToolWindowFactory : ToolWindowFactory {
         val panel = CodewalkerPanel(project)
         val content = ContentFactory.getInstance()
             .createContent(panel.root, "", false)
-        Disposer.register(toolWindow.disposable) { panel.dispose() }
+        Disposer.register(toolWindow.disposable, panel)
         toolWindow.contentManager.addContent(content)
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
@@ -1,69 +1,116 @@
 package com.snootbeestci.codewalker.toolwindow
 
+import codewalker.v1.Codewalker.PullRequestSummary
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
-import com.intellij.ui.components.JBTextField
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import com.snootbeestci.codewalker.forge.TokenStore
+import com.snootbeestci.codewalker.git.GitHubRemoteResolver
+import com.snootbeestci.codewalker.git.ProjectRepoInfo
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.session.ReviewErrorFormatter
 import com.snootbeestci.codewalker.settings.CodewalkerSettings
-import java.awt.GridBagConstraints
-import java.awt.GridBagLayout
-import java.awt.Insets
+import com.snootbeestci.codewalker.settings.CodewalkerSettingsConfigurable
+import git4idea.repo.GitRepositoryManager
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.FlowLayout
+import javax.swing.BoxLayout
 import javax.swing.JButton
 import javax.swing.JComboBox
-import javax.swing.JLabel
 import javax.swing.JPanel
-import javax.swing.event.DocumentEvent
-import javax.swing.event.DocumentListener
+import javax.swing.SwingConstants
 
-class IdlePanel {
+class IdlePanel(private val project: Project) {
 
-    val root: JPanel = JPanel(GridBagLayout())
-    private val urlField = JBTextField()
+    val root: JPanel = JPanel(BorderLayout())
+
     private val experienceLevelCombo = JComboBox(arrayOf("Junior", "Mid", "Senior"))
-    private val openReviewButton = JButton("Open Review")
-    private val errorLabel = JLabel("").apply {
+    private val refreshButton = JButton("Refresh")
+    private val subtitleLabel = JBLabel("").apply {
+        border = JBUI.Borders.empty(8, 12)
+    }
+    private val statusLabel = JBLabel("", SwingConstants.CENTER).apply {
+        border = JBUI.Borders.empty(16, 12)
+    }
+    private val errorLabel = JBLabel("").apply {
         foreground = JBColor.RED
+        border = JBUI.Borders.empty(4, 12)
         isVisible = false
     }
+    private val listContainer = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+    }
+    private val listScroll = JBScrollPane(listContainer).apply {
+        border = null
+    }
+    private val errorActions = JPanel(FlowLayout(FlowLayout.LEFT, 8, 4)).apply {
+        isVisible = false
+    }
+    private val configureTokensButton = JButton("Configure tokens").apply {
+        addActionListener {
+            ShowSettingsUtil.getInstance().showSettingsDialog(
+                project,
+                CodewalkerSettingsConfigurable::class.java,
+            )
+        }
+    }
+    private val retryButton = JButton("Retry").apply {
+        addActionListener { refreshPullRequests() }
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var prClickHandler: ((PullRequestSummary) -> Unit)? = null
 
     init {
         val settings = CodewalkerSettings.getInstance()
         experienceLevelCombo.selectedItem = displayLabel(settings.state.experienceLevel)
 
-        openReviewButton.isEnabled = false
-        urlField.emptyText.text = "Paste a GitHub PR, commit, or comparison URL"
-        urlField.document.addDocumentListener(object : DocumentListener {
-            override fun insertUpdate(e: DocumentEvent) = updateButton()
-            override fun removeUpdate(e: DocumentEvent) = updateButton()
-            override fun changedUpdate(e: DocumentEvent) = updateButton()
-            private fun updateButton() {
-                openReviewButton.isEnabled = urlField.text.isNotEmpty()
+        refreshButton.addActionListener { refreshPullRequests() }
+
+        val header = JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(8, 12, 0, 12)
+            add(JBLabel("Codewalker"), BorderLayout.WEST)
+            add(refreshButton, BorderLayout.EAST)
+        }
+
+        val centre = JPanel(BorderLayout()).apply {
+            add(subtitleLabel, BorderLayout.NORTH)
+            add(listScroll, BorderLayout.CENTER)
+            val statusWrapper = JPanel(BorderLayout()).apply {
+                add(statusLabel, BorderLayout.NORTH)
+                add(errorLabel, BorderLayout.CENTER)
+                add(errorActions, BorderLayout.SOUTH)
             }
-        })
+            add(statusWrapper, BorderLayout.SOUTH)
+        }
 
-        fun gbc(row: Int, fill: Int = GridBagConstraints.NONE, weightx: Double = 0.0) =
-            GridBagConstraints().apply {
-                gridx = 0; gridy = row
-                this.fill = fill
-                this.weightx = weightx
-                insets = Insets(4, 8, 4, 8)
-                anchor = GridBagConstraints.CENTER
-            }
+        val footer = JPanel(FlowLayout(FlowLayout.LEFT, 8, 8)).apply {
+            border = JBUI.Borders.customLineTop(JBColor.border())
+            add(JBLabel("Experience level:"))
+            add(experienceLevelCombo)
+        }
 
-        root.add(JLabel("Codewalker"), gbc(0))
-        root.add(urlField, gbc(1, GridBagConstraints.HORIZONTAL, 1.0))
-        root.add(experienceLevelCombo, gbc(2, GridBagConstraints.HORIZONTAL, 1.0))
-        root.add(openReviewButton, gbc(3))
-        root.add(errorLabel, gbc(4, GridBagConstraints.HORIZONTAL, 1.0))
-
-        root.add(JPanel(), GridBagConstraints().apply {
-            gridy = 5; weighty = 1.0; fill = GridBagConstraints.VERTICAL
-        })
+        root.add(header, BorderLayout.NORTH)
+        root.add(centre, BorderLayout.CENTER)
+        root.add(footer, BorderLayout.SOUTH)
     }
 
-    fun getUrl(): String = urlField.text
     fun getExperienceLevel(): String = selectedExperienceLevel()
 
-    fun setOpenReviewAction(action: () -> Unit) {
-        openReviewButton.addActionListener { action() }
+    fun setPullRequestClickHandler(handler: (PullRequestSummary) -> Unit) {
+        prClickHandler = handler
     }
 
     fun showError(message: String) {
@@ -74,6 +121,140 @@ class IdlePanel {
     fun clearError() {
         errorLabel.text = ""
         errorLabel.isVisible = false
+    }
+
+    fun dispose() {
+        scope.cancel()
+    }
+
+    fun refreshPullRequests() {
+        clearError()
+        clearList()
+        errorActions.isVisible = false
+
+        if (!hasGitRemote()) {
+            subtitleLabel.text = ""
+            showStatus("This project has no git remote configured. Configure VCS settings and try again.")
+            return
+        }
+
+        val info = GitHubRemoteResolver.resolve(project)
+        if (info == null) {
+            subtitleLabel.text = ""
+            showStatus(unsupportedRemoteMessage())
+            return
+        }
+
+        subtitleLabel.text = "Reviewing PRs for ${info.owner}/${info.repo}"
+        showStatus("Loading pull requests…")
+
+        val token = TokenStore.getInstance().get(info.host) ?: ""
+
+        scope.launch {
+            try {
+                val response = CodewalkerClient.getInstance().listPullRequests(
+                    host = info.host,
+                    owner = info.owner,
+                    repo = info.repo,
+                    forgeToken = token,
+                )
+                withContext(Dispatchers.Main) { renderPRs(info, response.pullRequestsList) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val msg = ReviewErrorFormatter.format(e)
+                withContext(Dispatchers.Main) { renderFetchError(msg) }
+            }
+        }
+    }
+
+    private fun hasGitRemote(): Boolean {
+        val repos = GitRepositoryManager.getInstance(project).repositories
+        return repos.any { it.remotes.isNotEmpty() }
+    }
+
+    private fun unsupportedRemoteMessage(): String {
+        val repos = GitRepositoryManager.getInstance(project).repositories
+        val origin = repos.firstNotNullOfOrNull { repo ->
+            repo.remotes.firstOrNull { it.name == "origin" }
+        } ?: return "This project has no `origin` remote configured. Configure VCS settings and try again."
+
+        val url = origin.firstUrl
+            ?: return "The `origin` remote has no URL. Configure VCS settings and try again."
+
+        // Try parsing as github first to give a more specific error
+        val parsed = GitHubRemoteResolver.parseRemoteUrl(url)
+        if (parsed == null) {
+            // Either non-GitHub host or unparseable
+            val host = extractHost(url)
+            return if (host != null) {
+                "Codewalker currently supports GitHub repositories only. The current project's `origin` remote points to $host."
+            } else {
+                "Could not parse the project's `origin` remote URL: $url."
+            }
+        }
+        return "Codewalker currently supports GitHub repositories only."
+    }
+
+    private fun extractHost(url: String): String? {
+        val cleaned = url.trim().removeSuffix("/").let {
+            if (it.endsWith(".git")) it.removeSuffix(".git") else it
+        }
+        Regex("""(?:ssh://)?git@([^:/]+)[:/].*""").matchEntire(cleaned)?.let {
+            return it.groupValues[1]
+        }
+        Regex("""https?://([^/]+)/.*""").matchEntire(cleaned)?.let {
+            return it.groupValues[1]
+        }
+        return null
+    }
+
+    private fun renderPRs(info: ProjectRepoInfo, prs: List<PullRequestSummary>) {
+        clearList()
+        if (prs.isEmpty()) {
+            showStatus("No open pull requests for ${info.owner}/${info.repo}.")
+            return
+        }
+        statusLabel.text = ""
+        statusLabel.isVisible = false
+        for (pr in prs) {
+            val item = PullRequestListItem(pr) { selected ->
+                prClickHandler?.invoke(selected)
+            }
+            item.root.alignmentX = Component.LEFT_ALIGNMENT
+            item.root.maximumSize = Dimension(Int.MAX_VALUE, item.root.preferredSize.height)
+            listContainer.add(item.root)
+        }
+        listContainer.revalidate()
+        listContainer.repaint()
+    }
+
+    private fun renderFetchError(message: String) {
+        clearList()
+        showStatus("")
+        showError("Couldn't load pull requests: $message")
+        errorActions.removeAll()
+        if (message.startsWith("Authorization required:") ||
+            message.contains("PERMISSION_DENIED", ignoreCase = true) ||
+            message.contains("UNAUTHENTICATED", ignoreCase = true)
+        ) {
+            errorActions.add(configureTokensButton)
+        }
+        errorActions.add(retryButton)
+        errorActions.isVisible = true
+        errorActions.revalidate()
+        errorActions.repaint()
+    }
+
+    private fun showStatus(text: String) {
+        statusLabel.text = text
+        statusLabel.isVisible = text.isNotEmpty()
+    }
+
+    private fun clearList() {
+        listContainer.removeAll()
+        listContainer.revalidate()
+        listContainer.repaint()
     }
 
     private fun selectedExperienceLevel(): String = when (experienceLevelCombo.selectedItem) {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
@@ -1,6 +1,7 @@
 package com.snootbeestci.codewalker.toolwindow
 
 import codewalker.v1.Codewalker.PullRequestSummary
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
@@ -10,11 +11,12 @@ import com.intellij.util.ui.JBUI
 import com.snootbeestci.codewalker.forge.TokenStore
 import com.snootbeestci.codewalker.git.GitHubRemoteResolver
 import com.snootbeestci.codewalker.git.ProjectRepoInfo
+import com.snootbeestci.codewalker.git.RemoteParseResult
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.session.FormattedError
 import com.snootbeestci.codewalker.session.ReviewErrorFormatter
 import com.snootbeestci.codewalker.settings.CodewalkerSettings
 import com.snootbeestci.codewalker.settings.CodewalkerSettingsConfigurable
-import git4idea.repo.GitRepositoryManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +34,7 @@ import javax.swing.JComboBox
 import javax.swing.JPanel
 import javax.swing.SwingConstants
 
-class IdlePanel(private val project: Project) {
+class IdlePanel(private val project: Project) : Disposable {
 
     val root: JPanel = JPanel(BorderLayout())
 
@@ -123,7 +125,7 @@ class IdlePanel(private val project: Project) {
         errorLabel.isVisible = false
     }
 
-    fun dispose() {
+    override fun dispose() {
         scope.cancel()
     }
 
@@ -132,17 +134,23 @@ class IdlePanel(private val project: Project) {
         clearList()
         errorActions.isVisible = false
 
-        if (!hasGitRemote()) {
-            subtitleLabel.text = ""
-            showStatus("This project has no git remote configured. Configure VCS settings and try again.")
-            return
-        }
-
-        val info = GitHubRemoteResolver.resolve(project)
-        if (info == null) {
-            subtitleLabel.text = ""
-            showStatus(unsupportedRemoteMessage())
-            return
+        val info = when (val r = GitHubRemoteResolver.resolveResult(project)) {
+            is RemoteParseResult.Empty -> {
+                subtitleLabel.text = ""
+                showStatus("This project has no git remote configured. Configure VCS settings and try again.")
+                return
+            }
+            is RemoteParseResult.Unparseable -> {
+                subtitleLabel.text = ""
+                showStatus("Could not parse the project's `origin` remote URL.")
+                return
+            }
+            is RemoteParseResult.NonGitHub -> {
+                subtitleLabel.text = ""
+                showStatus("Codewalker currently supports GitHub repositories only. The current project's `origin` remote points to ${r.host}.")
+                return
+            }
+            is RemoteParseResult.Ok -> r.info
         }
 
         subtitleLabel.text = "Reviewing PRs for ${info.owner}/${info.repo}"
@@ -162,51 +170,10 @@ class IdlePanel(private val project: Project) {
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                val msg = ReviewErrorFormatter.format(e)
-                withContext(Dispatchers.Main) { renderFetchError(msg) }
+                val formatted = ReviewErrorFormatter.format(e)
+                withContext(Dispatchers.Main) { renderFetchError(formatted) }
             }
         }
-    }
-
-    private fun hasGitRemote(): Boolean {
-        val repos = GitRepositoryManager.getInstance(project).repositories
-        return repos.any { it.remotes.isNotEmpty() }
-    }
-
-    private fun unsupportedRemoteMessage(): String {
-        val repos = GitRepositoryManager.getInstance(project).repositories
-        val origin = repos.firstNotNullOfOrNull { repo ->
-            repo.remotes.firstOrNull { it.name == "origin" }
-        } ?: return "This project has no `origin` remote configured. Configure VCS settings and try again."
-
-        val url = origin.firstUrl
-            ?: return "The `origin` remote has no URL. Configure VCS settings and try again."
-
-        // Try parsing as github first to give a more specific error
-        val parsed = GitHubRemoteResolver.parseRemoteUrl(url)
-        if (parsed == null) {
-            // Either non-GitHub host or unparseable
-            val host = extractHost(url)
-            return if (host != null) {
-                "Codewalker currently supports GitHub repositories only. The current project's `origin` remote points to $host."
-            } else {
-                "Could not parse the project's `origin` remote URL: $url."
-            }
-        }
-        return "Codewalker currently supports GitHub repositories only."
-    }
-
-    private fun extractHost(url: String): String? {
-        val cleaned = url.trim().removeSuffix("/").let {
-            if (it.endsWith(".git")) it.removeSuffix(".git") else it
-        }
-        Regex("""(?:ssh://)?git@([^:/]+)[:/].*""").matchEntire(cleaned)?.let {
-            return it.groupValues[1]
-        }
-        Regex("""https?://([^/]+)/.*""").matchEntire(cleaned)?.let {
-            return it.groupValues[1]
-        }
-        return null
     }
 
     private fun renderPRs(info: ProjectRepoInfo, prs: List<PullRequestSummary>) {
@@ -229,15 +196,12 @@ class IdlePanel(private val project: Project) {
         listContainer.repaint()
     }
 
-    private fun renderFetchError(message: String) {
+    private fun renderFetchError(formatted: FormattedError) {
         clearList()
         showStatus("")
-        showError("Couldn't load pull requests: $message")
+        showError("Couldn't load pull requests: ${formatted.message}")
         errorActions.removeAll()
-        if (message.startsWith("Authorization required:") ||
-            message.contains("PERMISSION_DENIED", ignoreCase = true) ||
-            message.contains("UNAUTHENTICATED", ignoreCase = true)
-        ) {
+        if (formatted.isAuthFailure) {
             errorActions.add(configureTokensButton)
         }
         errorActions.add(retryButton)

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/PullRequestListItem.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/PullRequestListItem.kt
@@ -1,0 +1,61 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import codewalker.v1.Codewalker.PullRequestSummary
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Cursor
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.BorderFactory
+import javax.swing.BoxLayout
+import javax.swing.JPanel
+
+class PullRequestListItem(
+    private val pr: PullRequestSummary,
+    private val onClick: (PullRequestSummary) -> Unit,
+) {
+
+    val root: JPanel = JPanel(BorderLayout())
+
+    init {
+        val content = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+        }
+
+        val titleLine = JBLabel("#${pr.number} ${pr.title}")
+        val authorLine = JBLabel("@${pr.author}").apply {
+            foreground = JBColor.GRAY
+        }
+
+        content.add(titleLine)
+        content.add(authorLine)
+
+        root.add(content, BorderLayout.CENTER)
+        root.border = BorderFactory.createCompoundBorder(
+            BorderFactory.createMatteBorder(0, 0, 1, 0, JBColor.border()),
+            JBUI.Borders.empty(8, 12),
+        )
+        root.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+
+        val hoverListener = object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                onClick(pr)
+            }
+
+            override fun mouseEntered(e: MouseEvent) {
+                root.background = JBColor.namedColor("List.hoverBackground", JBColor.LIGHT_GRAY)
+                root.isOpaque = true
+                root.repaint()
+            }
+
+            override fun mouseExited(e: MouseEvent) {
+                root.isOpaque = false
+                root.repaint()
+            }
+        }
+        root.addMouseListener(hoverListener)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,7 @@
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>Git4Idea</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.snootbeestci.codewalker.settings.CodewalkerSettings"/>

--- a/src/test/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolverTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolverTest.kt
@@ -3,6 +3,7 @@ package com.snootbeestci.codewalker.git
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class GitHubRemoteResolverTest {
@@ -111,5 +112,45 @@ class GitHubRemoteResolverTest {
         assertNull(GitHubRemoteResolver.parseRemoteUrl("not a url"))
         assertNull(GitHubRemoteResolver.parseRemoteUrl("https://github.com/just-owner"))
         assertNull(GitHubRemoteResolver.parseRemoteUrl("https://"))
+    }
+
+    @Test
+    fun `parseRemoteUrlResult ok for github url`() {
+        val r = GitHubRemoteResolver.parseRemoteUrlResult("https://github.com/owner/repo.git")
+        assertTrue(r is RemoteParseResult.Ok)
+        assertEquals("github.com", (r as RemoteParseResult.Ok).info.host)
+    }
+
+    @Test
+    fun `parseRemoteUrlResult non-github for gitlab`() {
+        val r = GitHubRemoteResolver.parseRemoteUrlResult("https://gitlab.com/owner/repo.git")
+        assertTrue(r is RemoteParseResult.NonGitHub)
+        assertEquals("gitlab.com", (r as RemoteParseResult.NonGitHub).host)
+    }
+
+    @Test
+    fun `parseRemoteUrlResult non-github for bitbucket via ssh`() {
+        val r = GitHubRemoteResolver.parseRemoteUrlResult("git@bitbucket.org:owner/repo.git")
+        assertTrue(r is RemoteParseResult.NonGitHub)
+        assertEquals("bitbucket.org", (r as RemoteParseResult.NonGitHub).host)
+    }
+
+    @Test
+    fun `parseRemoteUrlResult unparseable for gibberish`() {
+        val r = GitHubRemoteResolver.parseRemoteUrlResult("not a url")
+        assertTrue(r is RemoteParseResult.Unparseable)
+    }
+
+    @Test
+    fun `parseRemoteUrlResult empty for blank input`() {
+        assertTrue(GitHubRemoteResolver.parseRemoteUrlResult("") is RemoteParseResult.Empty)
+        assertTrue(GitHubRemoteResolver.parseRemoteUrlResult("   ") is RemoteParseResult.Empty)
+    }
+
+    @Test
+    fun `parseRemoteUrlResult host-only normalises case`() {
+        val r = GitHubRemoteResolver.parseRemoteUrlResult("https://GitLab.example.com/owner/repo")
+        assertTrue(r is RemoteParseResult.NonGitHub)
+        assertEquals("gitlab.example.com", (r as RemoteParseResult.NonGitHub).host)
     }
 }

--- a/src/test/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolverTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolverTest.kt
@@ -1,0 +1,115 @@
+package com.snootbeestci.codewalker.git
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class GitHubRemoteResolverTest {
+
+    @Test
+    fun `https github url parses`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("https://github.com/snootbeestci/codewalker")
+        assertNotNull(info)
+        assertEquals("github.com", info!!.host)
+        assertEquals("snootbeestci", info.owner)
+        assertEquals("codewalker", info.repo)
+    }
+
+    @Test
+    fun `https github url with dot-git suffix parses`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("https://github.com/snootbeestci/codewalker.git")
+        assertNotNull(info)
+        assertEquals("github.com", info!!.host)
+        assertEquals("snootbeestci", info.owner)
+        assertEquals("codewalker", info.repo)
+    }
+
+    @Test
+    fun `https github url with trailing slash parses`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("https://github.com/snootbeestci/codewalker/")
+        assertNotNull(info)
+        assertEquals("codewalker", info!!.repo)
+    }
+
+    @Test
+    fun `ssh short form parses`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("git@github.com:snootbeestci/codewalker.git")
+        assertNotNull(info)
+        assertEquals("github.com", info!!.host)
+        assertEquals("snootbeestci", info.owner)
+        assertEquals("codewalker", info.repo)
+    }
+
+    @Test
+    fun `ssh short form without dot-git parses`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("git@github.com:owner/repo")
+        assertNotNull(info)
+        assertEquals("github.com", info!!.host)
+        assertEquals("owner", info.owner)
+        assertEquals("repo", info.repo)
+    }
+
+    @Test
+    fun `ssh long form parses`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("ssh://git@github.com/owner/repo.git")
+        assertNotNull(info)
+        assertEquals("github.com", info!!.host)
+        assertEquals("owner", info.owner)
+        assertEquals("repo", info.repo)
+    }
+
+    @Test
+    fun `github enterprise host is accepted`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("https://github.mycompany.com/team/service.git")
+        assertNotNull(info)
+        assertEquals("github.mycompany.com", info!!.host)
+        assertEquals("team", info.owner)
+        assertEquals("service", info.repo)
+    }
+
+    @Test
+    fun `github enterprise via ssh is accepted`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("git@github.mycompany.com:team/service.git")
+        assertNotNull(info)
+        assertEquals("github.mycompany.com", info!!.host)
+    }
+
+    @Test
+    fun `mixed case host is normalised to lowercase`() {
+        val info = GitHubRemoteResolver.parseRemoteUrl("https://GitHub.MyCompany.com/Owner/Repo.git")
+        assertNotNull(info)
+        assertEquals("github.mycompany.com", info!!.host)
+        // Owner/repo casing is preserved — only the host is canonicalised.
+        assertEquals("Owner", info.owner)
+        assertEquals("Repo", info.repo)
+    }
+
+    @Test
+    fun `gitlab host is rejected`() {
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("https://gitlab.com/owner/repo.git"))
+    }
+
+    @Test
+    fun `bitbucket host is rejected`() {
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("git@bitbucket.org:owner/repo.git"))
+    }
+
+    @Test
+    fun `gitea host is rejected`() {
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("https://gitea.example.com/owner/repo"))
+    }
+
+    @Test
+    fun `empty input returns null`() {
+        assertNull(GitHubRemoteResolver.parseRemoteUrl(""))
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("   "))
+    }
+
+    @Test
+    fun `malformed input returns null`() {
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("not a url"))
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("https://github.com/just-owner"))
+        assertNull(GitHubRemoteResolver.parseRemoteUrl("https://"))
+    }
+}

--- a/src/test/kotlin/com/snootbeestci/codewalker/session/ReviewErrorFormatterTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/session/ReviewErrorFormatterTest.kt
@@ -16,71 +16,81 @@ class ReviewErrorFormatterTest {
 
     @Test
     fun `non-status exception falls through to message`() {
-        val msg = ReviewErrorFormatter.format(IllegalStateException("boom"))
-        assertEquals("boom", msg)
+        val r = ReviewErrorFormatter.format(IllegalStateException("boom"))
+        assertEquals("boom", r.message)
+        assertEquals(false, r.isAuthFailure)
     }
 
     @Test
     fun `null message yields fallback string`() {
-        val msg = ReviewErrorFormatter.format(RuntimeException())
-        assertEquals("Unknown error", msg)
+        val r = ReviewErrorFormatter.format(RuntimeException())
+        assertEquals("Unknown error", r.message)
+        assertEquals(false, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied without description yields generic string`() {
         val e = StatusRuntimeException(Status.PERMISSION_DENIED, Metadata())
-        assertEquals("Permission denied", ReviewErrorFormatter.format(e))
+        val r = ReviewErrorFormatter.format(e)
+        assertEquals("Permission denied", r.message)
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with plain bad-token body returns the body`() {
-        val e = permissionDenied("Bad credentials")
-        assertEquals("Bad credentials", ReviewErrorFormatter.format(e))
+        val r = ReviewErrorFormatter.format(permissionDenied("Bad credentials"))
+        assertEquals("Bad credentials", r.message)
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with associated branch description is not tagged`() {
-        val e = permissionDenied("This PR is associated with a protected branch")
-        val msg = ReviewErrorFormatter.format(e)
-        assertEquals(false, msg.startsWith("Authorization required:"))
+        val r = ReviewErrorFormatter.format(
+            permissionDenied("This PR is associated with a protected branch")
+        )
+        assertEquals(false, r.message.startsWith("Authorization required:"))
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with crossorigin description is not tagged`() {
-        val e = permissionDenied("Cross-origin requests are not permitted on this endpoint")
-        val msg = ReviewErrorFormatter.format(e)
-        assertEquals(false, msg.startsWith("Authorization required:"))
+        val r = ReviewErrorFormatter.format(
+            permissionDenied("Cross-origin requests are not permitted on this endpoint")
+        )
+        assertEquals(false, r.message.startsWith("Authorization required:"))
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with bare SSO acronym alone is not tagged`() {
-        val e = permissionDenied("SSO is not the issue here")
-        val msg = ReviewErrorFormatter.format(e)
-        // After tightening, bare "SSO" alone no longer triggers the prefix.
-        assertEquals(false, msg.startsWith("Authorization required:"))
+        val r = ReviewErrorFormatter.format(permissionDenied("SSO is not the issue here"))
+        assertEquals(false, r.message.startsWith("Authorization required:"))
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with SAML enforcement body is tagged as authorization required`() {
         val body = "Resource protected by organization SAML enforcement. " +
             "You must grant your OAuth token access to this organization."
-        val e = permissionDenied(body)
-        val msg = ReviewErrorFormatter.format(e)
-        assertEquals("Authorization required: $body", msg)
+        val r = ReviewErrorFormatter.format(permissionDenied(body))
+        assertEquals("Authorization required: $body", r.message)
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with single sign-on marker is tagged as authorization required`() {
-        val e = permissionDenied("Single sign-on required for org foo")
-        val msg = ReviewErrorFormatter.format(e)
-        assertEquals(true, msg.startsWith("Authorization required:"))
+        val r = ReviewErrorFormatter.format(permissionDenied("Single sign-on required for org foo"))
+        assertEquals(true, r.message.startsWith("Authorization required:"))
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
     fun `permission denied with admin rights marker is tagged as authorization required`() {
-        val e = permissionDenied("Token must have admin rights to access this org")
-        val msg = ReviewErrorFormatter.format(e)
-        assertEquals(true, msg.startsWith("Authorization required:"))
+        val r = ReviewErrorFormatter.format(
+            permissionDenied("Token must have admin rights to access this org")
+        )
+        assertEquals(true, r.message.startsWith("Authorization required:"))
+        assertEquals(true, r.isAuthFailure)
     }
 
     @Test
@@ -89,9 +99,36 @@ class ReviewErrorFormatterTest {
             Status.NOT_FOUND.withDescription("no such PR"),
             Metadata()
         )
-        val msg = ReviewErrorFormatter.format(e)
-        // StatusRuntimeException.message is "NOT_FOUND: no such PR" — we don't
-        // dictate the format here, just confirm the path is the default.
-        assertEquals(true, msg.contains("no such PR"))
+        val r = ReviewErrorFormatter.format(e)
+        assertEquals(true, r.message.contains("no such PR"))
+    }
+
+    @Test
+    fun `unauthenticated status is auth failure`() {
+        val e = StatusRuntimeException(
+            Status.UNAUTHENTICATED.withDescription("token expired"),
+            Metadata(),
+        )
+        val r = ReviewErrorFormatter.format(e)
+        assertEquals("token expired", r.message)
+        assertEquals(true, r.isAuthFailure)
+    }
+
+    @Test
+    fun `unauthenticated without description has fallback message`() {
+        val e = StatusRuntimeException(Status.UNAUTHENTICATED, Metadata())
+        val r = ReviewErrorFormatter.format(e)
+        assertEquals("Authentication required", r.message)
+        assertEquals(true, r.isAuthFailure)
+    }
+
+    @Test
+    fun `not-found status is not an auth failure`() {
+        val e = StatusRuntimeException(
+            Status.NOT_FOUND.withDescription("no such PR"),
+            Metadata(),
+        )
+        val r = ReviewErrorFormatter.format(e)
+        assertEquals(false, r.isAuthFailure)
     }
 }


### PR DESCRIPTION
Closes #26.

## Summary

Replaces the free-text URL field on the idle screen with a list of open pull requests for the current project's GitHub remote, fetched via the new `ListPullRequests` RPC.

## Changes

- **`build.gradle.kts`** — bump `codewalker-proto` from `v0.3.10` to `v0.5.0` to pick up the new RPC, and add `bundledPlugin("Git4Idea")` so `GitRepositoryManager` is on the compile classpath.
- **`plugin.xml`** — declare the `Git4Idea` runtime dependency.
- **`com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt`** (new) — resolves a project's `origin` remote into a canonical `(host, owner, repo)` triple. Exposes a sealed `RemoteParseResult` with `Ok`, `NonGitHub(host)`, `Unparseable`, and `Empty` variants — single source of truth for URL → host parsing in the plugin. Hosts are normalised via `HostNormalizer.normalize`.
- **`com/snootbeestci/codewalker/grpc/CodewalkerClient.kt`** — `listPullRequests` suspend function wrapping the new RPC.
- **`com/snootbeestci/codewalker/toolwindow/PullRequestListItem.kt`** (new) — clickable PR row showing `#N title` and `@author`, with hover highlight and a hand cursor.
- **`com/snootbeestci/codewalker/toolwindow/IdlePanel.kt`** — full redesign: header with refresh button, subtitle, scrollable PR list, footer retaining the experience-level combo. Implements `Disposable`; the `CoroutineScope` is cancelled via the disposer chain. All panel states render off `RemoteParseResult` directly — no host-extraction logic remains here. `renderFetchError` consumes `FormattedError.isAuthFailure` to decide whether to show **Configure tokens**; no more string-matching.
- **`com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt`** — implements `Disposable`; registers `IdlePanel` via `Disposer.register` so cancellation cascades automatically. Triggers `refreshPullRequests()` on `CONNECTED` transitions.
- **`com/snootbeestci/codewalker/toolwindow/CodewalkerToolWindowFactory.kt`** — registers `CodewalkerPanel` via `Disposer.register(toolWindow.disposable, panel)`, replacing the lambda-based call.
- **`com/snootbeestci/codewalker/session/ReviewErrorFormatter.kt`** — `format` now returns `FormattedError(message, isAuthFailure)`. `UNAUTHENTICATED` is classified as an auth failure alongside `PERMISSION_DENIED`. Callers consult `isAuthFailure` directly.
- **`com/snootbeestci/codewalker/session/ReviewSessionController.kt`** — replace URL-button wiring with `setPullRequestClickHandler { pr -> openReview(pr.url, …) }`. Updated to use `formatted.message` from the new `FormattedError`.
- **`com/snootbeestci/codewalker/git/GitHubRemoteResolverTest.kt`** — table-driven coverage of `parseRemoteUrl` (HTTPS, SSH, GHE, mixed-case, non-GitHub, empty/malformed) plus six new `parseRemoteUrlResult` cases pinning the sealed-result behaviour.
- **`com/snootbeestci/codewalker/session/ReviewErrorFormatterTest.kt`** — every case adapted to assert on the new `FormattedError` shape; three new cases for `UNAUTHENTICATED` (with and without description) and a `NOT_FOUND` negative pin for `isAuthFailure`.
- **`codewalker-intellij-briefing.md`** — `Project entry point` section documents the new flow, the Git4Idea dependency, the `RemoteParseResult` sealed type, and the host-parsing single-source-of-truth rule. `403 / SSO error rendering` rewritten to describe the structured `FormattedError`. New Kotlin development rule: panels owning a `CoroutineScope` must implement `Disposable` and be registered via `Disposer.register`.
- **`README.md`** — updated the "Review a PR" step to describe clicking a PR row instead of pasting a URL.

## Commits

1. `feat: list open PRs for current project on idle screen` — the feature itself plus tests, briefing, and README.
2. `build: add Git4Idea bundled plugin to compile classpath` — fixes the CI build by making `git4idea.repo.GitRepositoryManager` resolvable at compile time.
3. `refactor: structured error and remote-parse results` — addresses review feedback: structured `FormattedError`, sealed `RemoteParseResult`, `IdlePanel`/`CodewalkerPanel` as `Disposable` registered via `Disposer.register`, plus tests and briefing updates.

## Test plan

- [ ] CI runs `./gradlew check` — green. (Cannot run locally in this session: the sandbox blocks JitPack and JetBrains repos required to download `codewalker-proto:v0.5.0` and the IntelliJ IDEA platform.)
- [ ] Manually open the plugin in a sandboxed IDE on a project with a GitHub `origin` and confirm: the idle screen lists open PRs; clicking a row opens a review session against that PR's `html_url`; the refresh button refetches.
- [ ] Manually verify each panel state: no git remote, non-GitHub remote, unparseable remote URL, loading, public-repo empty list, public-repo populated list, auth failure shows Configure tokens, other failure shows Retry.
- [ ] Manually verify private-repo mode works once a token is configured for the matching host in Settings → Tools → Codewalker.
