### PR TITLE
feat: render PR head-ref content for review sessions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.5.0") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.6.0") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -229,6 +229,43 @@ path elsewhere in the plugin — host parsing lives in one place.
 
 ---
 
+## Review session file display
+
+Review session highlights are applied against the PR's head-ref content,
+not the working-tree copy. The plugin fetches file content via the
+backend's `FetchFileAtRef` RPC, which wraps the same forge handler used
+by session opening.
+
+Resolution order:
+
+1. Fetch the head-ref content (cached per session, keyed by path+ref)
+2. If the working-tree copy exists and is byte-equal, open the real
+   `VirtualFile` — preserves IDE features like Find Usages and run
+   configurations
+3. Otherwise open a read-only `LightVirtualFile` named
+   `<filename> @ <short-ref>` showing the head-ref content
+
+This matches the diff's line numbers to the displayed content
+unconditionally. Working-tree drift no longer produces silent
+misalignment.
+
+Fetch failures fall back to the working-tree copy with a user-visible
+status message; the user is never silently shown the wrong content.
+`NOT_FOUND` from the backend is treated as "file genuinely doesn't
+exist at the head ref" — no fallback, the highlight is cleared and
+the user is notified.
+
+`EditorHighlighter` owns its own `CoroutineScope` (IO dispatcher,
+`SupervisorJob`) and is registered via `Disposer.register(parent, child)`
+from `SessionPanel`. The scope is cancelled and the per-session content
+cache cleared on dispose. `SessionPanel.bind` calls `highlighter.bind`
+with the active session's `ForgeContext` so the highlighter can resolve
+`(host, owner, repo, headRef)` for `FetchFileAtRef` calls. Without a
+bound context the highlighter logs and returns — it never falls back to
+opening the working-tree copy unconditionally.
+
+---
+
 ## Future direction
 
 - **Walkthrough sessions** — explain a file in the open project step by step

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -1,6 +1,8 @@
 package com.snootbeestci.codewalker.editor
 
+import codewalker.v1.Codewalker.ForgeContext
 import codewalker.v1.Codewalker.HunkSpan
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -12,37 +14,147 @@ import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.LightVirtualFile
 import com.intellij.ui.JBColor
+import com.snootbeestci.codewalker.forge.HostNormalizer
+import com.snootbeestci.codewalker.forge.TokenStore
+import com.snootbeestci.codewalker.grpc.CodewalkerClient
+import com.snootbeestci.codewalker.session.ReviewErrorFormatter
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.awt.Color
 
-class EditorHighlighter(private val project: Project) {
+class EditorHighlighter(
+    private val project: Project,
+    private val statusReporter: (String) -> Unit = {},
+) : Disposable {
 
     private val log = Logger.getInstance(EditorHighlighter::class.java)
 
     private var currentHighlighters: List<RangeHighlighter> = emptyList()
     private var currentEditor: Editor? = null
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val contentCache = mutableMapOf<Pair<String, String>, ByteArray>()
+    private var boundContext: BoundContext? = null
+
+    fun bind(forgeContext: ForgeContext?) {
+        boundContext = forgeContext?.let {
+            val host = HostNormalizer.fromUrl(it.url)
+            if (host.isEmpty() || it.owner.isEmpty() || it.repo.isEmpty() || it.headRef.isEmpty()) {
+                null
+            } else {
+                BoundContext(host = host, owner = it.owner, repo = it.repo, headRef = it.headRef)
+            }
+        }
+        contentCache.clear()
+    }
+
     fun highlightHunk(span: HunkSpan) {
+        val ctx = boundContext
+        if (ctx == null) {
+            log.debug("Codewalker: highlightHunk called before forge context bound")
+            return
+        }
+
+        scope.launch {
+            val headContent = try {
+                fetchHeadContent(ctx, span.filePath)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                handleFetchFailure(span, e)
+                return@launch
+            }
+
+            withContext(Dispatchers.Main) {
+                applyHighlightToBestEditor(span, ctx.headRef, headContent)
+            }
+        }
+    }
+
+    private suspend fun fetchHeadContent(ctx: BoundContext, path: String): ByteArray {
+        val key = path to ctx.headRef
+        contentCache[key]?.let { return it }
+        val token = TokenStore.getInstance().get(ctx.host) ?: ""
+        val content = CodewalkerClient.getInstance().fetchFileAtRef(
+            host = ctx.host,
+            owner = ctx.owner,
+            repo = ctx.repo,
+            path = path,
+            ref = ctx.headRef,
+            forgeToken = token,
+        )
+        contentCache[key] = content
+        return content
+    }
+
+    private suspend fun handleFetchFailure(span: HunkSpan, e: Exception) {
+        val notFound = e is StatusRuntimeException && e.status.code == Status.Code.NOT_FOUND
+        if (notFound) {
+            withContext(Dispatchers.Main) {
+                clearHighlight()
+                statusReporter("${span.filePath} not found at PR head ref")
+            }
+            return
+        }
+        val formatted = ReviewErrorFormatter.format(e)
+        val baseMsg = if (formatted.isAuthFailure) {
+            formatted.message
+        } else {
+            "Couldn't fetch ${span.filePath} at PR head — showing working-tree copy, " +
+                "which may not match the diff."
+        }
+        withContext(Dispatchers.Main) {
+            statusReporter(baseMsg)
+            applyHighlightWorkingTreeFallback(span)
+        }
+    }
+
+    private fun applyHighlightWorkingTreeFallback(span: HunkSpan) {
         clearHighlight()
-
-        val virtualFile = findFile(span.filePath)
-        if (virtualFile == null) {
-            log.debug("Codewalker: file not found in project: ${span.filePath} (basePath=${project.basePath})")
+        val workingFile = findWorkingTreeFile(span.filePath)
+        if (workingFile == null) {
+            log.debug("Codewalker: no working-tree fallback available for ${span.filePath}")
             return
         }
-        val editor = openOrFocus(virtualFile)
-        if (editor == null) {
-            log.debug("Codewalker: openTextEditor returned null for ${virtualFile.path}")
-            return
-        }
-
+        val editor = openOrFocus(workingFile) ?: return
         currentEditor = editor
+        applyHighlightRanges(editor, span)
+    }
 
+    private fun applyHighlightToBestEditor(span: HunkSpan, headRef: String, headContent: ByteArray) {
+        clearHighlight()
+        val workingFile = findWorkingTreeFile(span.filePath)
+        val workingBytes = workingFile?.let { file ->
+            ReadAction.compute<ByteArray, RuntimeException> { file.contentsToByteArray() }
+        }
+        val editor = when (val choice = chooseEditor(workingFile, workingBytes, headContent, headRef)) {
+            is EditorChoice.WorkingTree -> openOrFocus(choice.file)
+            is EditorChoice.LightVirtual -> openHeadRefContent(span.filePath, choice.ref, choice.content)
+        }
+        if (editor == null) {
+            log.debug("Codewalker: could not open an editor for ${span.filePath}")
+            return
+        }
+        currentEditor = editor
+        applyHighlightRanges(editor, span)
+    }
+
+    private fun applyHighlightRanges(editor: Editor, span: HunkSpan) {
         val document = editor.document
         val ranges = computeAddedLineRanges(span.rawDiff, span.newStart)
 
@@ -72,14 +184,6 @@ class EditorHighlighter(private val project: Project) {
             .coerceAtLeast(0)
             .coerceAtMost(document.lineCount - 1)
 
-        if (firstHighlightLine - 1 > document.lineCount - 1) {
-            log.debug(
-                "Codewalker: hunk targets line $firstHighlightLine but working-tree " +
-                    "${span.filePath} has only ${document.lineCount} lines — file is " +
-                    "likely out of sync with the PR head. Scrolling to end of file."
-            )
-        }
-
         editor.scrollingModel.scrollTo(
             LogicalPosition(scrollLine, 0),
             ScrollType.CENTER
@@ -92,13 +196,7 @@ class EditorHighlighter(private val project: Project) {
         currentEditor = null
     }
 
-    // TODO: this opens the working-tree copy of the file, which can disagree
-    // with the PR head ref's content. Hunks may reference lines that don't
-    // exist in the working tree, or highlight unrelated lines if the working
-    // tree is on a different branch. Fetching the file at the PR head ref via
-    // the backend's FetchFile RPC and rendering it in a virtual editor would
-    // be the principled fix. Tracked separately.
-    private fun findFile(filePath: String): VirtualFile? {
+    private fun findWorkingTreeFile(filePath: String): VirtualFile? {
         val basePath = project.basePath
         if (basePath != null) {
             val direct = LocalFileSystem.getInstance().findFileByPath("$basePath/$filePath")
@@ -119,8 +217,36 @@ class EditorHighlighter(private val project: Project) {
             .openTextEditor(descriptor, true)
     }
 
-    fun dispose() {
+    private fun openHeadRefContent(path: String, ref: String, content: ByteArray): Editor? {
+        val fileName = path.substringAfterLast('/')
+        val displayName = "$fileName @ ${ref.take(7)}"
+        val virtualFile = LightVirtualFile(
+            displayName,
+            FileTypeManager.getInstance().getFileTypeByFileName(fileName),
+            String(content, Charsets.UTF_8),
+        ).apply {
+            isWritable = false
+        }
+        val descriptor = OpenFileDescriptor(project, virtualFile)
+        return FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+    }
+
+    override fun dispose() {
+        scope.cancel()
+        contentCache.clear()
         clearHighlight()
+    }
+
+    internal data class BoundContext(
+        val host: String,
+        val owner: String,
+        val repo: String,
+        val headRef: String,
+    )
+
+    internal sealed class EditorChoice {
+        data class WorkingTree(val file: VirtualFile) : EditorChoice()
+        data class LightVirtual(val content: ByteArray, val ref: String) : EditorChoice()
     }
 
     companion object {
@@ -163,6 +289,20 @@ class EditorHighlighter(private val project: Project) {
                 ranges.add(rangeStart..(currentNewLine - 1))
             }
             return ranges
+        }
+
+        internal fun chooseEditor(
+            workingTree: VirtualFile?,
+            workingTreeBytes: ByteArray?,
+            headContent: ByteArray,
+            ref: String,
+        ): EditorChoice = when {
+            workingTree == null || workingTreeBytes == null ->
+                EditorChoice.LightVirtual(headContent, ref)
+            workingTreeBytes.contentEquals(headContent) ->
+                EditorChoice.WorkingTree(workingTree)
+            else ->
+                EditorChoice.LightVirtual(headContent, ref)
         }
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerClient.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/grpc/CodewalkerClient.kt
@@ -2,6 +2,7 @@ package com.snootbeestci.codewalker.grpc
 
 import codewalker.v1.CodeWalkerGrpcKt
 import codewalker.v1.Codewalker.ListPullRequestsResponse
+import codewalker.v1.fetchFileAtRefRequest
 import codewalker.v1.getVersionRequest
 import codewalker.v1.listPullRequestsRequest
 import com.intellij.openapi.Disposable
@@ -69,6 +70,26 @@ class CodewalkerClient : Disposable {
             this.repo = repo
             this.forgeToken = forgeToken
         })
+    }
+
+    suspend fun fetchFileAtRef(
+        host: String,
+        owner: String,
+        repo: String,
+        path: String,
+        ref: String,
+        forgeToken: String,
+    ): ByteArray {
+        val s = stub ?: error("Not connected to backend")
+        val response = s.fetchFileAtRef(fetchFileAtRefRequest {
+            this.host = host
+            this.owner = owner
+            this.repo = repo
+            this.path = path
+            this.ref = ref
+            this.forgeToken = forgeToken
+        })
+        return response.content.toByteArray()
     }
 
     override fun dispose() { disconnect() }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -17,7 +17,7 @@ class CodewalkerPanel(project: Project) : Disposable {
     private val disconnectedPanel = DisconnectedPanel()
     internal val idlePanel = IdlePanel(project)
     internal val loadingPanel = LoadingPanel()
-    private val sessionPanel = SessionPanel(project)
+    private val sessionPanel = SessionPanel(project, onStatusMessage = ::showError)
     private val controller = ReviewSessionController(this)
 
     init {
@@ -27,6 +27,7 @@ class CodewalkerPanel(project: Project) : Disposable {
         root.add(sessionPanel.root, "SESSION")
 
         Disposer.register(this, idlePanel)
+        Disposer.register(this, sessionPanel)
 
         project.messageBus.connect(project).subscribe(
             CodewalkerClient.CONNECTION_STATE_TOPIC,
@@ -68,7 +69,6 @@ class CodewalkerPanel(project: Project) : Disposable {
 
     override fun dispose() {
         controller.dispose()
-        sessionPanel.dispose()
         disconnectedPanel.dispose()
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -3,8 +3,10 @@ package com.snootbeestci.codewalker.toolwindow
 import codewalker.v1.Codewalker.EdgeLabel
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.Codewalker.StepComplete
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.ui.components.JBScrollPane
 import com.snootbeestci.codewalker.editor.EditorHighlighter
 import com.snootbeestci.codewalker.session.NavigationController
@@ -27,12 +29,17 @@ import javax.swing.JTextPane
 import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
 
-class SessionPanel(private val project: Project) {
+class SessionPanel(
+    private val project: Project,
+    private val onStatusMessage: (String) -> Unit = {},
+) : Disposable {
 
     val root: JPanel = JPanel(GridBagLayout())
 
     private val log = Logger.getInstance(SessionPanel::class.java)
-    private val highlighter = EditorHighlighter(project)
+    private val highlighter = EditorHighlighter(project, onStatusMessage).also {
+        Disposer.register(this, it)
+    }
 
     private val titleLabel = JLabel("Codewalker")
     private val languageLabel = JLabel(" ")
@@ -153,6 +160,7 @@ class SessionPanel(private val project: Project) {
         this.controller = controller
         this.navigationController?.dispose()
         this.navigationController = NavigationController(controller, this)
+        highlighter.bind(controller.forgeContext)
         updateLanguageBadge(controller)
         updateLevelPips(controller.effectiveLevel)
         populateStepList(controller.steps)
@@ -165,10 +173,9 @@ class SessionPanel(private val project: Project) {
         controller.currentStepId?.let { navigationController?.navigateTo(it) }
     }
 
-    fun dispose() {
+    override fun dispose() {
         navigationController?.dispose()
         navigationController = null
-        highlighter.dispose()
     }
 
     fun clearNarration() {

--- a/src/test/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighterTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighterTest.kt
@@ -1,6 +1,10 @@
 package com.snootbeestci.codewalker.editor
 
+import com.intellij.testFramework.LightVirtualFile
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class EditorHighlighterTest {
@@ -130,5 +134,72 @@ class EditorHighlighterTest {
         val ranges = EditorHighlighter.computeAddedLineRanges(diff, 10)
 
         assertEquals(listOf(11..11), ranges)
+    }
+
+    @Test
+    fun `content equality - same bytes match`() {
+        assertTrue(byteArrayOf(1, 2, 3).contentEquals(byteArrayOf(1, 2, 3)))
+    }
+
+    @Test
+    fun `content equality - different bytes don't match`() {
+        assertFalse(byteArrayOf(1, 2, 3).contentEquals(byteArrayOf(1, 2, 4)))
+    }
+
+    @Test
+    fun `content equality - empty arrays match each other`() {
+        assertTrue(byteArrayOf().contentEquals(byteArrayOf()))
+    }
+
+    @Test
+    fun `chooseEditor - no working tree file picks LightVirtual`() {
+        val head = byteArrayOf(1, 2, 3)
+        val choice = EditorHighlighter.chooseEditor(null, null, head, "abc1234")
+
+        assertTrue(choice is EditorHighlighter.EditorChoice.LightVirtual)
+        choice as EditorHighlighter.EditorChoice.LightVirtual
+        assertSame(head, choice.content)
+        assertEquals("abc1234", choice.ref)
+    }
+
+    @Test
+    fun `chooseEditor - working tree with matching content picks WorkingTree`() {
+        val file = LightVirtualFile("a.kt")
+        val bytes = byteArrayOf(1, 2, 3)
+        val choice = EditorHighlighter.chooseEditor(file, bytes, byteArrayOf(1, 2, 3), "abc1234")
+
+        assertTrue(choice is EditorHighlighter.EditorChoice.WorkingTree)
+        choice as EditorHighlighter.EditorChoice.WorkingTree
+        assertSame(file, choice.file)
+    }
+
+    @Test
+    fun `chooseEditor - working tree with different content picks LightVirtual`() {
+        val file = LightVirtualFile("a.kt")
+        val choice = EditorHighlighter.chooseEditor(
+            file,
+            byteArrayOf(1, 2, 3),
+            byteArrayOf(9, 9, 9),
+            "abc1234",
+        )
+
+        assertTrue(choice is EditorHighlighter.EditorChoice.LightVirtual)
+    }
+
+    @Test
+    fun `chooseEditor - working tree empty with non-empty head picks LightVirtual`() {
+        val file = LightVirtualFile("a.kt")
+        val head = byteArrayOf(1, 2, 3)
+        val choice = EditorHighlighter.chooseEditor(file, byteArrayOf(), head, "abc1234")
+
+        assertTrue(choice is EditorHighlighter.EditorChoice.LightVirtual)
+    }
+
+    @Test
+    fun `chooseEditor - both empty picks WorkingTree`() {
+        val file = LightVirtualFile("a.kt")
+        val choice = EditorHighlighter.chooseEditor(file, byteArrayOf(), byteArrayOf(), "abc1234")
+
+        assertTrue(choice is EditorHighlighter.EditorChoice.WorkingTree)
     }
 }


### PR DESCRIPTION
Closes #35.

## Summary

Review session highlights now apply against the PR's head-ref content fetched via the new `FetchFileAtRef` RPC, rather than the working-tree copy. This unconditionally aligns the diff's line numbers with the displayed content — files added in a PR or files that have drifted on the working branch no longer produce silent misalignment.

## Commits in this PR

- `feat: render PR head-ref content for review sessions` — single commit covering everything below.

## Changes

### Proto / RPC

- Bumps `codewalker-proto` to `v0.6.0`.
- `CodewalkerClient.fetchFileAtRef(host, owner, repo, path, ref, forgeToken)` wraps the new RPC and returns the response body as a `ByteArray`.

### `EditorHighlighter`

- Now implements `Disposable`. Owns its own `CoroutineScope(SupervisorJob() + Dispatchers.IO)`. The scope is cancelled and the per-session content cache (`Map<Pair<String, String>, ByteArray>`, keyed by `(path, ref)`) is cleared in `dispose()`.
- New `bind(ForgeContext?)` method captures `(host, owner, repo, headRef)` extracted from the active session's forge context. `host` is derived via `HostNormalizer.fromUrl(forgeContext.url)` to match the canonical-host contract used elsewhere. `bind(null)` (or any context missing one of those four strings) clears the binding.
- `highlightHunk(span)` is now a fire-and-forget that launches on the highlighter's own scope, does the network round trip on the IO dispatcher, then dispatches the editor work back to the EDT via `withContext(Dispatchers.Main)`. If no context is bound it logs and returns.
- New resolution order:
  1. Fetch head-ref content (cached by `(path, ref)` per session).
  2. If the working-tree file exists and its bytes are byte-equal to the head content, open the real `VirtualFile` — preserves IDE features like Find Usages and run configurations.
  3. Otherwise open a read-only `LightVirtualFile` named `<filename> @ <short-ref>`.
- `chooseEditor(workingTree, workingTreeBytes, headContent, ref): EditorChoice` is the pure function that encodes step 2/3 — extracted to be unit-testable.
- The old TODO comment about working-tree drift is removed.

### Failure UX

- `NOT_FOUND` from the backend ⇒ no working-tree fallback, status message reads `"<path> not found at PR head ref"`.
- Auth failures (`PERMISSION_DENIED` / `UNAUTHENTICATED`) ⇒ working-tree fallback, status message comes from `ReviewErrorFormatter.format` so SSO-tagged messages are surfaced verbatim.
- Other errors ⇒ working-tree fallback with `"Couldn't fetch <path> at PR head — showing working-tree copy, which may not match the diff."`
- Status messages are reported via the existing `panel.showError` channel (passed in as a `(String) -> Unit` callback by `CodewalkerPanel`).

### Wiring

- `SessionPanel` now implements `Disposable`. The highlighter is created via `Disposer.register(this, it)` so cancellation cascades from `CodewalkerPanel` → `SessionPanel` → `EditorHighlighter` automatically. The manual `highlighter.dispose()` call in `SessionPanel.dispose()` and the manual `sessionPanel.dispose()` call in `CodewalkerPanel.dispose()` are removed (briefing's "manual child.dispose() in parent.dispose() is a code smell" rule).
- `SessionPanel.bind(controller)` now calls `highlighter.bind(controller.forgeContext)` after wiring the navigation controller.
- `CodewalkerPanel` constructs `SessionPanel(project, onStatusMessage = ::showError)` and registers it via `Disposer.register`.

### Tests

- Six new unit tests in `EditorHighlighterTest`: three for byte-array content equality (degenerate cases), and the five-case `chooseEditor` matrix from the issue (no working tree → LightVirtual; matching → WorkingTree; differing → LightVirtual; empty working tree + non-empty head → LightVirtual; both empty → WorkingTree).

### Briefing

- New "Review session file display" section documenting the resolution order, fallback semantics, and the disposable/scope/bind ownership pattern.

## Local check status

`./gradlew check` could not be run locally — the sandbox firewall blocks `cache-redirector.jetbrains.com` and `download.jetbrains.com`, so the IntelliJ Platform dependency cannot resolve. The branch is structured exactly to the issue's specification; CI will verify.

## Test plan

- [ ] CI runs `./gradlew check` green
- [ ] **Original bug reproduction** — PR adds a line, working tree on `main` without that line; click PR → highlight lands on the correct line of a `LightVirtualFile` titled `<file> @ <short-ref>`
- [ ] **Working-tree match** — check out the PR head branch locally, click the same PR → real working-tree file opens (no `@ <ref>` suffix)
- [ ] **New file in PR** — PR adds a brand new file; click → opens `LightVirtualFile`, working-tree path is skipped
- [ ] **Fetch failure** — disable network, click PR → fallback to working-tree with status message; doesn't crash
- [ ] **Cache** — navigate forward and back through hunks in the same file → second access is instant (cache hit)


---
_Generated by [Claude Code](https://claude.ai/code/session_015XXpHtfpT1YcQsWoEjLtSD)_