### PR TITLE
Move token retrieval inside coroutine scope in IdlePanel

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/IdlePanel.kt
@@ -156,9 +156,8 @@ class IdlePanel(private val project: Project) : Disposable {
         subtitleLabel.text = "Reviewing PRs for ${info.owner}/${info.repo}"
         showStatus("Loading pull requests…")
 
-        val token = TokenStore.getInstance().get(info.host) ?: ""
-
         scope.launch {
+            val token = TokenStore.getInstance().get(info.host) ?: ""
             try {
                 val response = CodewalkerClient.getInstance().listPullRequests(
                     host = info.host,


### PR DESCRIPTION
## Summary
Moved the token retrieval operation inside the coroutine scope to ensure it executes on the appropriate dispatcher context.

## Key Changes
- Moved `TokenStore.getInstance().get(info.host)` call from outside the `scope.launch` block into inside it
- This ensures the token retrieval happens within the coroutine context rather than on the UI thread

## Implementation Details
The token is now retrieved after entering the coroutine scope, which is a better practice for operations that may involve I/O or need to respect the dispatcher context. This change maintains the same functionality while improving the threading model of the code.

https://claude.ai/code/session_0156zX7M4TxmHucDGbLXogNr