### PR TITLE
feat: clean up session view layout

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -110,15 +110,21 @@ Registered as a right-side tool window. Four states managed via `CardLayout`:
 
 ### Session body layout
 
-Inside the SESSION card, the body is split horizontally:
+Inside the SESSION card, the body is a horizontal `JBSplitter`:
 
-- **West**: step list (grouped by file path)
-- **Centre**: a vertical column of
-  - `SummaryTable` — fixed two-column key/value list rendering the eight
-    `StepSummary` fields. Always visible. Empty/unset fields render as `—`
-    so the layout never collapses.
-  - `CollapsibleSection` wrapping the streamed narration `JTextPane`.
-    Collapsed by default — clicking the header toggles visibility.
+- **First component**: file step list, scrollable, with a subtitle row
+  showing the longest common directory prefix across all changed files.
+  Per-file headers show the path relative to that prefix.
+- **Second component**: a vertical `JBSplitter` whose
+  - **First component** is the summary panel: a `SummaryTable` pinned to
+    the top via `BorderLayout.NORTH`, with a filler below to anchor it.
+    Cell values are read-only `JTextArea`s with `lineWrap = true` so long
+    text wraps to multiple lines rather than scrolling or truncating.
+  - **Second component** is the `CollapsibleSection` wrapping the
+    streamed narration. Collapsed by default; clicking the header
+    expands it. When expanded, the vertical splitter divider becomes
+    draggable so the user can reapportion space between summary and
+    narration.
 
 `SessionPanel.onStepComplete` calls `summaryTable.update(complete.summary)`
 when `complete.hasSummary()` is true, otherwise passes `null` (which clears
@@ -299,6 +305,10 @@ opening the working-tree copy unconditionally.
   via `Disposer.register(parent, child)` so cancellation cascades
   automatically — manual `child.dispose()` calls in a parent's
   `dispose()` are a code smell.
+- Resizable body sections use `JBSplitter` (horizontal or vertical) with
+  a proportional initial position and a 3px divider. Avoid `BorderLayout`
+  with fixed-width children when the user might want to see more of one
+  side than the other.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CollapsibleSection.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CollapsibleSection.kt
@@ -10,7 +10,12 @@ import java.awt.event.MouseEvent
 import javax.swing.BorderFactory
 import javax.swing.JPanel
 
-class CollapsibleSection(title: String, private val content: Component, expanded: Boolean = false) {
+class CollapsibleSection(
+    title: String,
+    private val content: Component,
+    expanded: Boolean = false,
+    private val onToggle: (Boolean) -> Unit = {},
+) {
 
     val root: JPanel = JPanel(BorderLayout())
 
@@ -42,6 +47,7 @@ class CollapsibleSection(title: String, private val content: Component, expanded
         arrowLabel.icon = if (isExpanded) AllIcons.General.ArrowDown else AllIcons.General.ArrowRight
         root.revalidate()
         root.repaint()
+        onToggle(isExpanded)
     }
 
     fun expand() {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -7,7 +7,9 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.JBSplitter
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
 import com.snootbeestci.codewalker.editor.EditorHighlighter
 import com.snootbeestci.codewalker.session.NavigationController
 import com.snootbeestci.codewalker.session.ReviewSessionController
@@ -19,7 +21,6 @@ import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.Insets
 import javax.swing.BorderFactory
-import javax.swing.BoxLayout
 import javax.swing.DefaultListModel
 import javax.swing.JButton
 import javax.swing.JLabel
@@ -28,6 +29,25 @@ import javax.swing.JPanel
 import javax.swing.JTextPane
 import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
+
+internal fun longestCommonDirectoryPrefix(paths: List<String>): String {
+    if (paths.isEmpty()) return ""
+    if (paths.size == 1) {
+        return paths[0].substringBeforeLast('/', "").let { if (it.isEmpty()) "" else "$it/" }
+    }
+    val split = paths.map { it.split('/') }
+    val minLen = split.minOf { it.size } - 1
+    var common = 0
+    outer@ for (i in 0 until minLen) {
+        val first = split[0][i]
+        for (other in split.drop(1)) {
+            if (other[i] != first) break@outer
+        }
+        common++
+    }
+    if (common == 0) return ""
+    return split[0].take(common).joinToString("/", postfix = "/")
+}
 
 class SessionPanel(
     private val project: Project,
@@ -58,10 +78,16 @@ class SessionPanel(
         preferredSize = Dimension(360, 180)
         minimumSize = Dimension(200, 120)
     }
+    private val bodyColumn = JBSplitter(true, 0.7f).apply {
+        dividerWidth = 3
+    }
     private val narrationCollapsible = CollapsibleSection(
         title = "Detailed narration",
         content = narrationScroll,
-        expanded = false
+        expanded = false,
+        onToggle = { expanded ->
+            bodyColumn.proportion = if (expanded) 0.7f else COLLAPSED_PROPORTION
+        }
     )
     private val backButton = JButton("← Back").apply { isEnabled = false }
     private val forwardButton = JButton("Forward →").apply { isEnabled = false }
@@ -97,8 +123,7 @@ class SessionPanel(
         breadcrumbLabel.border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
 
         val stepListScroll = JBScrollPane(stepList).apply {
-            preferredSize = Dimension(220, 200)
-            minimumSize = Dimension(160, 120)
+            minimumSize = Dimension(120, 80)
         }
 
         val navBar = JPanel(GridBagLayout()).apply {
@@ -115,15 +140,21 @@ class SessionPanel(
             })
         }
 
-        val bodyColumn = JPanel().apply {
-            layout = BoxLayout(this, BoxLayout.Y_AXIS)
-            add(summaryTable.root)
-            add(narrationCollapsible.root)
+        val summaryWrapper = JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(8, 0, 0, 0)
+            add(summaryTable.root, BorderLayout.NORTH)
+            add(JPanel().apply { isOpaque = false }, BorderLayout.CENTER)
         }
 
-        val body = JPanel(BorderLayout()).apply {
-            add(stepListScroll, BorderLayout.WEST)
-            add(bodyColumn, BorderLayout.CENTER)
+        bodyColumn.firstComponent = summaryWrapper
+        bodyColumn.secondComponent = narrationCollapsible.root
+        // Initial state: narration collapsed → give summary almost all the space.
+        bodyColumn.proportion = COLLAPSED_PROPORTION
+
+        val bodySplitter = JBSplitter(false, 0.3f).apply {
+            firstComponent = stepListScroll
+            secondComponent = bodyColumn
+            dividerWidth = 3
         }
 
         fun row(component: Component, gridy: Int, weighty: Double, fill: Int) {
@@ -136,7 +167,7 @@ class SessionPanel(
 
         row(header, 0, 0.0, GridBagConstraints.HORIZONTAL)
         row(breadcrumbLabel, 1, 0.0, GridBagConstraints.HORIZONTAL)
-        row(body, 2, 1.0, GridBagConstraints.BOTH)
+        row(bodySplitter, 2, 1.0, GridBagConstraints.BOTH)
         row(navBar, 3, 0.0, GridBagConstraints.HORIZONTAL)
     }
 
@@ -146,7 +177,7 @@ class SessionPanel(
         stepList.addListSelectionListener { event ->
             if (event.valueIsAdjusting) return@addListSelectionListener
             val item = stepList.selectedValue ?: return@addListSelectionListener
-            if (item is StepListItem.Header) {
+            if (item is StepListItem.Header || item is StepListItem.Subtitle) {
                 stepList.clearSelection()
                 return@addListSelectionListener
             }
@@ -234,8 +265,17 @@ class SessionPanel(
             }
             grouped.getOrPut(path.ifEmpty { "(unknown)" }) { mutableListOf() }.add(step)
         }
+        val prefix = longestCommonDirectoryPrefix(grouped.keys.toList())
+        if (prefix.isNotEmpty()) {
+            stepListModel.addElement(StepListItem.Subtitle(prefix))
+        }
         for ((path, fileSteps) in grouped) {
-            stepListModel.addElement(StepListItem.Header(path))
+            val displayPath = if (prefix.isNotEmpty() && path.startsWith(prefix)) {
+                path.removePrefix(prefix)
+            } else {
+                path
+            }
+            stepListModel.addElement(StepListItem.Header(displayPath))
             fileSteps.forEachIndexed { index, step ->
                 val span = step.hunkSpan
                 val end = span.newStart + maxOf(span.newLines, 1) - 1
@@ -258,6 +298,7 @@ class SessionPanel(
     }
 
     private sealed class StepListItem {
+        data class Subtitle(val text: String) : StepListItem()
         data class Header(val filePath: String) : StepListItem()
         data class StepRow(val stepId: String, val label: String) : StepListItem()
     }
@@ -273,6 +314,7 @@ class SessionPanel(
             cellHasFocus: Boolean
         ): Component {
             val text = when (value) {
+                is StepListItem.Subtitle -> value.text
                 is StepListItem.Header -> value.filePath
                 is StepListItem.StepRow -> "    " + value.label
             }
@@ -280,13 +322,23 @@ class SessionPanel(
             val component = delegate.getListCellRendererComponent(
                 list, text, index, showSelected, cellHasFocus
             ) as JLabel
-            if (value is StepListItem.Header) {
-                component.font = component.font.deriveFont(Font.BOLD)
-                component.horizontalAlignment = SwingConstants.LEFT
-                component.background = list.background
-                component.foreground = list.foreground
-            } else {
-                component.font = component.font.deriveFont(Font.PLAIN)
+            when (value) {
+                is StepListItem.Subtitle -> {
+                    val baseSize = component.font.size2D
+                    component.font = component.font.deriveFont(Font.ITALIC, baseSize - 1f)
+                    component.horizontalAlignment = SwingConstants.LEFT
+                    component.background = list.background
+                    component.foreground = list.foreground
+                }
+                is StepListItem.Header -> {
+                    component.font = component.font.deriveFont(Font.BOLD)
+                    component.horizontalAlignment = SwingConstants.LEFT
+                    component.background = list.background
+                    component.foreground = list.foreground
+                }
+                is StepListItem.StepRow -> {
+                    component.font = component.font.deriveFont(Font.PLAIN)
+                }
             }
             return component
         }
@@ -294,5 +346,6 @@ class SessionPanel(
 
     companion object {
         private const val MAX_LEVEL = 10
+        private const val COLLAPSED_PROPORTION = 0.95f
     }
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTable.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTable.kt
@@ -8,24 +8,27 @@ import java.awt.GridBagLayout
 import java.awt.Insets
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.JTextArea
+import javax.swing.UIManager
 
 class SummaryTable {
 
     val root: JPanel = JPanel(GridBagLayout())
 
-    private val rows: List<Pair<String, JLabel>> = listOf(
-        "Breaking" to JLabel(EMPTY_VALUE),
-        "Risk" to JLabel(EMPTY_VALUE),
-        "What changed" to JLabel(EMPTY_VALUE),
-        "Side effects" to JLabel(EMPTY_VALUE),
-        "Tests" to JLabel(EMPTY_VALUE),
-        "Reviewer focus" to JLabel(EMPTY_VALUE),
-        "Suggestion" to JLabel(EMPTY_VALUE),
-        "Confidence" to JLabel(EMPTY_VALUE),
+    private val rows: List<Pair<String, JTextArea>> = listOf(
+        "Breaking" to makeValueCell(),
+        "Risk" to makeValueCell(),
+        "What changed" to makeValueCell(),
+        "Side effects" to makeValueCell(),
+        "Tests" to makeValueCell(),
+        "Reviewer focus" to makeValueCell(),
+        "Suggestion" to makeValueCell(),
+        "Confidence" to makeValueCell(),
     )
 
     init {
-        rows.forEachIndexed { index, (label, valueLabel) ->
+        rows.forEachIndexed { index, (label, valueCell) ->
+            valueCell.text = EMPTY_VALUE
             val keyLabel = JLabel(label).apply {
                 font = font.deriveFont(Font.BOLD)
                 foreground = JBColor.GRAY
@@ -35,10 +38,11 @@ class SummaryTable {
                 anchor = GridBagConstraints.NORTHWEST
                 insets = Insets(2, 8, 2, 12)
             })
-            root.add(valueLabel, GridBagConstraints().apply {
+            root.add(valueCell, GridBagConstraints().apply {
                 gridx = 1; gridy = index
                 weightx = 1.0
-                fill = GridBagConstraints.HORIZONTAL
+                weighty = 0.0
+                fill = GridBagConstraints.BOTH
                 anchor = GridBagConstraints.NORTHWEST
                 insets = Insets(2, 0, 2, 8)
             })
@@ -61,12 +65,22 @@ class SummaryTable {
     }
 
     fun clear() {
-        rows.forEach { (_, label) -> label.text = EMPTY_VALUE }
+        rows.forEach { (_, cell) -> cell.text = EMPTY_VALUE }
     }
 
-    fun valueLabelAt(index: Int): JLabel = rows[index].second
+    fun valueLabelAt(index: Int): JTextArea = rows[index].second
 
     companion object {
         const val EMPTY_VALUE: String = "—"
+
+        private fun makeValueCell(): JTextArea = JTextArea().apply {
+            isEditable = false
+            lineWrap = true
+            wrapStyleWord = true
+            isOpaque = false
+            border = null
+            background = null
+            font = UIManager.getFont("Label.font") ?: font
+        }
     }
 }

--- a/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanelTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanelTest.kt
@@ -1,0 +1,96 @@
+package com.snootbeestci.codewalker.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SessionPanelTest {
+
+    @Test
+    fun `empty list returns empty prefix`() {
+        assertEquals("", longestCommonDirectoryPrefix(emptyList()))
+    }
+
+    @Test
+    fun `single file at root returns empty prefix`() {
+        assertEquals("", longestCommonDirectoryPrefix(listOf("Foo.kt")))
+    }
+
+    @Test
+    fun `single file in directory returns its directory`() {
+        assertEquals("src/", longestCommonDirectoryPrefix(listOf("src/Foo.kt")))
+    }
+
+    @Test
+    fun `single file in nested directory returns its full directory`() {
+        assertEquals(
+            "src/main/kotlin/",
+            longestCommonDirectoryPrefix(listOf("src/main/kotlin/Foo.kt"))
+        )
+    }
+
+    @Test
+    fun `two files sharing prefix returns the prefix`() {
+        assertEquals(
+            "src/main/kotlin/",
+            longestCommonDirectoryPrefix(
+                listOf("src/main/kotlin/Foo.kt", "src/main/kotlin/Bar.kt")
+            )
+        )
+    }
+
+    @Test
+    fun `two files with no common prefix returns empty`() {
+        assertEquals(
+            "",
+            longestCommonDirectoryPrefix(listOf("src/Foo.kt", "test/Bar.kt"))
+        )
+    }
+
+    @Test
+    fun `one path is a directory prefix of the other returns shared prefix`() {
+        assertEquals(
+            "src/",
+            longestCommonDirectoryPrefix(listOf("src/Foo.kt", "src/main/Bar.kt"))
+        )
+    }
+
+    @Test
+    fun `mixed depths with no common parent returns empty`() {
+        assertEquals(
+            "",
+            longestCommonDirectoryPrefix(listOf("Foo.kt", "src/Bar.kt"))
+        )
+    }
+
+    @Test
+    fun `three files share two segments and diverge below`() {
+        assertEquals(
+            "a/b/",
+            longestCommonDirectoryPrefix(
+                listOf("a/b/c/Foo.kt", "a/b/d/Bar.kt", "a/b/e/Baz.kt")
+            )
+        )
+    }
+
+    @Test
+    fun `identical paths return the directory portion`() {
+        assertEquals(
+            "src/main/",
+            longestCommonDirectoryPrefix(
+                listOf("src/main/Foo.kt", "src/main/Foo.kt")
+            )
+        )
+    }
+
+    @Test
+    fun `directory boundary is respected not character boundary`() {
+        // "src/main/foo" and "src/main/foobar" should collapse at directory boundary,
+        // not include the partial segment match.
+        assertEquals(
+            "src/main/",
+            longestCommonDirectoryPrefix(
+                listOf("src/main/foo/A.kt", "src/main/foobar/B.kt")
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Addresses five aesthetic issues in the session view:

- **File list — common prefix collapse.** Extracted `longestCommonDirectoryPrefix` (computed on directory boundaries, not character boundaries) and used it to render a single italic, smaller-font subtitle row at the top of the step list. Per-file headers now show the path relative to that prefix. Empty / single-file / mixed-depth edge cases are handled.
- **File list scrolling and resizing.** Replaced the fixed-width `BorderLayout.WEST` step list with a horizontal `JBSplitter` (proportion `0.3f`, 3px divider). Dropped `preferredSize` on the scroll pane; kept `minimumSize = 120×80` so the user can't drag it to invisibility.
- **Summary table — vertical alignment.** Wrapped `summaryTable.root` in a `JPanel(BorderLayout())` with the table at `NORTH` and a transparent filler at `CENTER` so the summary pins to the top of its area. Added an 8px top margin via `JBUI.Borders.empty(8, 0, 0, 0)` for breathing room below the breadcrumb.
- **Summary table — wrapping cells.** `SummaryTable` value cells are now read-only `JTextArea`s (`lineWrap = true`, `wrapStyleWord = true`, `isOpaque = false`, `background = null`) so long values wrap to multiple lines instead of being clipped or truncated. `GridBagConstraints` for value cells use `fill = BOTH` and `weighty = 0.0` so each row sizes naturally to its content. `valueLabelAt` now returns `JTextArea` (only `.text` is read in the existing tests).
- **Detailed narration — anchored, splittable.** The body column became a vertical `JBSplitter`. Top half is the summary wrapper; bottom half is the (still-collapsible) narration. `CollapsibleSection` gained an optional `onToggle: (Boolean) -> Unit` callback so `SessionPanel` can move the splitter `proportion` between `0.95f` (collapsed → summary gets nearly all the space) and `0.7f` (expanded → divider draggable to reapportion).

### Implementation notes

- `longestCommonDirectoryPrefix` is a top-level `internal` function in `SessionPanel.kt` so it's reachable from the new `SessionPanelTest` without making the existing `StepListItem` sealed class non-private.
- A new `StepListItem.Subtitle` variant carries the prefix; the renderer styles it italic, one point smaller than the base font, with `list.background` so it reads as a caption. The selection listener now rejects both `Header` and `Subtitle` clicks.

## Tests

- `SessionPanelTest` — table-driven JUnit5 tests for `longestCommonDirectoryPrefix`:
  - empty list → `""`
  - single file at root → `""`
  - single file in directory → `"src/"`
  - single file in nested directory → full directory chain
  - two files sharing prefix → returns prefix
  - two files with no common prefix → `""`
  - one path is a directory prefix of the other → shared prefix
  - mixed depths with no common parent → `""`
  - three files share two segments and diverge below → `"a/b/"`
  - identical paths → directory portion
  - directory boundary respected (not character boundary): `src/main/foo/A.kt` + `src/main/foobar/B.kt` → `"src/main/"`

`./gradlew check` could not be run in the sandbox (the IntelliJ platform tarball is fetched from `download.jetbrains.com`, which is blocked here). CI will run it on this PR.

### Manual verification list

- [ ] Open a PR touching files in a deep directory → file list shows the common prefix once as a subtitle, headers show only the diverging part
- [ ] Open a PR touching files at the repo root → no subtitle, headers show full filename
- [ ] Drag the splitter between file list and body → file list resizes, doesn't snap back
- [ ] Drag the splitter to collapse the file list to its minimum (120px) → can't go below that
- [ ] Open a PR with very long filenames → file list shows scrollbar when needed; widening via splitter reveals the full name
- [ ] Open a PR with a long `what_changed` summary → text wraps within the panel, doesn't disappear off-screen
- [ ] Expand the detailed narration → splitter divider becomes draggable, user can rebalance
- [ ] Collapse the narration → divider snaps to give the summary panel the available space

## Briefing

Updated `### Session body layout` to describe the new horizontal-then-vertical splitter structure and the wrapping `JTextArea` summary cells. Added a new bullet under `### Kotlin` development rules covering `JBSplitter` for resizable body sections.

https://claude.ai/code/session_018wbLwGyfnL8H5qeX4a223M

---
_Generated by [Claude Code](https://claude.ai/code/session_018wbLwGyfnL8H5qeX4a223M)_