### PR TITLE
fix: anchor detailed narration to bottom of summary panel

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -115,16 +115,18 @@ Inside the SESSION card, the body is a horizontal `JBSplitter`:
 - **First component**: file step list, scrollable, with a subtitle row
   showing the longest common directory prefix across all changed files.
   Per-file headers show the path relative to that prefix.
-- **Second component**: a vertical `JBSplitter` whose
-  - **First component** is the summary panel: a `SummaryTable` pinned to
-    the top via `BorderLayout.NORTH`, with a filler below to anchor it.
-    Cell values are read-only `JTextArea`s with `lineWrap = true` so long
-    text wraps to multiple lines rather than scrolling or truncating.
-  - **Second component** is the `CollapsibleSection` wrapping the
-    streamed narration. Collapsed by default; clicking the header
-    expands it. When expanded, the vertical splitter divider becomes
-    draggable so the user can reapportion space between summary and
-    narration.
+- **Second component**: a single panel laid out with `GridBagLayout`:
+  - **Top** — `SummaryTable`, anchored to the top of the panel via
+    `weighty = 0.0` and `anchor = NORTH`. Cell values are read-only
+    `JTextArea`s with `lineWrap = true` so long text wraps to multiple
+    lines rather than scrolling or truncating.
+  - **Middle** — empty filler with `weighty = 1.0` that absorbs leftover
+    vertical space.
+  - **Bottom** — `CollapsibleSection` wrapping the streamed narration
+    `JTextPane`, anchored to the bottom of the panel via
+    `weighty = 0.0` and `anchor = SOUTH`. Collapsed by default; clicking
+    the header expands it. The narration grows upward into the filler
+    space; the summary stays where it is.
 
 `SessionPanel.onStepComplete` calls `summaryTable.update(complete.summary)`
 when `complete.hasSummary()` is true, otherwise passes `null` (which clears
@@ -305,10 +307,6 @@ opening the working-tree copy unconditionally.
   via `Disposer.register(parent, child)` so cancellation cascades
   automatically — manual `child.dispose()` calls in a parent's
   `dispose()` are a code smell.
-- Resizable body sections use `JBSplitter` (horizontal or vertical) with
-  a proportional initial position and a 3px divider. Avoid `BorderLayout`
-  with fixed-width children when the user might want to see more of one
-  side than the other.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -13,7 +13,6 @@ import com.intellij.util.ui.JBUI
 import com.snootbeestci.codewalker.editor.EditorHighlighter
 import com.snootbeestci.codewalker.session.NavigationController
 import com.snootbeestci.codewalker.session.ReviewSessionController
-import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.Font
@@ -78,16 +77,10 @@ class SessionPanel(
         preferredSize = Dimension(360, 180)
         minimumSize = Dimension(200, 120)
     }
-    private val bodyColumn = JBSplitter(true, 0.7f).apply {
-        dividerWidth = 3
-    }
     private val narrationCollapsible = CollapsibleSection(
         title = "Detailed narration",
         content = narrationScroll,
         expanded = false,
-        onToggle = { expanded ->
-            bodyColumn.proportion = if (expanded) 0.7f else COLLAPSED_PROPORTION
-        }
     )
     private val backButton = JButton("← Back").apply { isEnabled = false }
     private val forwardButton = JButton("Forward →").apply { isEnabled = false }
@@ -140,20 +133,30 @@ class SessionPanel(
             })
         }
 
-        val summaryWrapper = JPanel(BorderLayout()).apply {
+        val summaryWrapper = JPanel(GridBagLayout()).apply {
             border = JBUI.Borders.empty(8, 0, 0, 0)
-            add(summaryTable.root, BorderLayout.NORTH)
-            add(JPanel().apply { isOpaque = false }, BorderLayout.CENTER)
+            add(summaryTable.root, GridBagConstraints().apply {
+                gridx = 0; gridy = 0
+                weightx = 1.0; weighty = 0.0
+                fill = GridBagConstraints.HORIZONTAL
+                anchor = GridBagConstraints.NORTH
+            })
+            add(JPanel().apply { isOpaque = false }, GridBagConstraints().apply {
+                gridx = 0; gridy = 1
+                weightx = 1.0; weighty = 1.0
+                fill = GridBagConstraints.BOTH
+            })
+            add(narrationCollapsible.root, GridBagConstraints().apply {
+                gridx = 0; gridy = 2
+                weightx = 1.0; weighty = 0.0
+                fill = GridBagConstraints.HORIZONTAL
+                anchor = GridBagConstraints.SOUTH
+            })
         }
-
-        bodyColumn.firstComponent = summaryWrapper
-        bodyColumn.secondComponent = narrationCollapsible.root
-        // Initial state: narration collapsed → give summary almost all the space.
-        bodyColumn.proportion = COLLAPSED_PROPORTION
 
         val bodySplitter = JBSplitter(false, 0.3f).apply {
             firstComponent = stepListScroll
-            secondComponent = bodyColumn
+            secondComponent = summaryWrapper
             dividerWidth = 3
         }
 
@@ -346,6 +349,5 @@ class SessionPanel(
 
     companion object {
         private const val MAX_LEVEL = 10
-        private const val COLLAPSED_PROPORTION = 0.95f
     }
 }


### PR DESCRIPTION
## Summary

Replaces the vertical `JBSplitter` between summary and narration with a
single `GridBagLayout` panel:

- Summary anchored at the top (`weighty = 0.0`, `anchor = NORTH`)
- Filler with `weighty = 1.0` in the middle absorbing leftover space
- Narration anchored at the bottom (`weighty = 0.0`, `anchor = SOUTH`)

The narration's `CollapsibleSection` header now always sits at the
bottom edge of the right pane. Clicking it grows the narration upward
into the filler space; the summary stays put at the top. Closes #39.

### Code changes

- `SessionPanel.kt`:
  - Drop `bodyColumn` `JBSplitter` and `COLLAPSED_PROPORTION` constant
  - Drop the narration `onToggle` callback (the default no-op is enough;
    `CollapsibleSection.toggle` already calls `revalidate()`)
  - Replace the `BorderLayout` summary wrapper with a three-row
    `GridBagLayout` (summary / filler / narration)
  - Hand `summaryWrapper` directly to the horizontal `bodySplitter`'s
    `secondComponent`
  - Remove the unused `java.awt.BorderLayout` import

### Briefing

- Replaced the `### Session body layout` section to describe the new
  `GridBagLayout` arrangement
- Removed the dev-rules bullet that mandated `JBSplitter` for resizable
  body sections — vertical splittability for the narration was the
  wrong shape

## Test plan

This is a layout-only change; no unit tests added.

- [ ] `./gradlew check` passes (CI)
- [ ] Open a review session — narration header sits at the bottom edge
  of the right panel
- [ ] Click the narration header to expand — narration grows upward,
  summary stays put at the top
- [ ] Click again to collapse — narration shrinks, header returns to
  the bottom edge
- [ ] Resize the IDE window taller — narration header stays anchored,
  the gap above it grows, summary stays at the top
- [ ] Resize narrower — summary cells wrap, narration header still
  anchored at bottom

https://claude.ai/code/session_01Np4EXbXom6TkQFRtwKaq68

---
_Generated by [Claude Code](https://claude.ai/code/session_01Np4EXbXom6TkQFRtwKaq68)_