### PR TITLE
diag: LightVirtualFile open investigation in EditorHighlighter

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -3,7 +3,6 @@ package com.snootbeestci.codewalker.editor
 import codewalker.v1.Codewalker.ForgeContext
 import codewalker.v1.Codewalker.HunkSpan
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -233,27 +232,25 @@ class EditorHighlighter(
                 isWritable = false
             }
         }
-        val descriptor = OpenFileDescriptor(project, virtualFile)
         val manager = FileEditorManager.getInstance(project)
 
-        // Open synchronously without focus to avoid the LightVirtualFile race
-        // where openTextEditor tries to focus a not-yet-fully-constructed editor.
-        val editor = manager.openTextEditor(descriptor, false)
+        // openFile reliably handles repeat opens of LightVirtualFile where
+        // openTextEditor returns null after the first one.
+        manager.openFile(virtualFile, /* focusEditor = */ false, /* searchForOpen = */ true)
 
-        // Bring the tab to the foreground on the next EDT cycle. By that point
-        // the editor's preferredFocusedComponent is wired up. We pass
-        // focusEditor = false because we only want tab selection, not
-        // inner-component focus (which is what races on LightVirtualFile).
-        ApplicationManager.getApplication().invokeLater {
-            manager.openFile(virtualFile, /* focusEditor = */ false, /* searchForOpen = */ true)
-        }
+        // Explicitly select the tab — openFile alone doesn't always bring it
+        // to the foreground when another file is currently selected.
+        manager.setSelectedEditor(virtualFile, "text-editor")
 
         log.info(
             "Codewalker: opened head-ref tab for $path; selected file is " +
                 "${manager.selectedFiles.firstOrNull()?.name}"
         )
 
-        return editor
+        // Fetch the editor instance for highlighting. By this point the tab
+        // is selected and the underlying TextEditor is available.
+        return (manager.getSelectedEditor(virtualFile) as? com.intellij.openapi.fileEditor.TextEditor)
+            ?.editor
     }
 
     override fun dispose() {

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -228,7 +228,7 @@ class EditorHighlighter(
             isWritable = false
         }
         val descriptor = OpenFileDescriptor(project, virtualFile)
-        return FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+        return FileEditorManager.getInstance(project).openTextEditor(descriptor, false)
     }
 
     override fun dispose() {

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -14,7 +14,6 @@ import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
-import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -233,15 +232,13 @@ class EditorHighlighter(
                 isWritable = false
             }
         }
-        val manager = FileEditorManager.getInstance(project)
-        // openFile selects the tab without focusing the inner editor component,
-        // avoiding the LightVirtualFile focus race while still bringing the
-        // correct tab to the foreground.
-        manager.openFile(virtualFile, /* focusEditor = */ false, /* searchForOpen = */ true)
-        return (manager.getSelectedEditor(virtualFile) as? TextEditor)?.editor
-            ?: manager.allEditors.filterIsInstance<TextEditor>()
-                .firstOrNull { it.file == virtualFile }
-                ?.editor
+        val descriptor = OpenFileDescriptor(project, virtualFile)
+        val editor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+        log.info(
+            "Codewalker: opened head-ref tab for $path; selected file is " +
+                "${FileEditorManager.getInstance(project).selectedFiles.firstOrNull()?.name}"
+        )
+        return editor
     }
 
     override fun dispose() {

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -50,6 +50,7 @@ class EditorHighlighter(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val contentCache = mutableMapOf<Pair<String, String>, ByteArray>()
     private val virtualFileCache = mutableMapOf<Pair<String, String>, LightVirtualFile>()
+    private var currentLightFile: LightVirtualFile? = null
     private var boundContext: BoundContext? = null
 
     fun bind(forgeContext: ForgeContext?) {
@@ -63,6 +64,7 @@ class EditorHighlighter(
         }
         contentCache.clear()
         virtualFileCache.clear()
+        currentLightFile = null
     }
 
     fun highlightHunk(span: HunkSpan) {
@@ -234,29 +236,33 @@ class EditorHighlighter(
         }
         val manager = FileEditorManager.getInstance(project)
 
-        // openFile reliably handles repeat opens of LightVirtualFile where
-        // openTextEditor returns null after the first one.
-        manager.openFile(virtualFile, /* focusEditor = */ false, /* searchForOpen = */ true)
+        // Close the previously-opened Codewalker tab if it's different from
+        // the one we're about to open. IntelliJ's editor manager has issues
+        // switching tabs between LightVirtualFiles via openTextEditor /
+        // openFile / setSelectedEditor; closing the old one first sidesteps
+        // the issue.
+        val previous = currentLightFile
+        if (previous != null && previous != virtualFile) {
+            manager.closeFile(previous)
+        }
+        currentLightFile = virtualFile
 
-        // Explicitly select the tab — openFile alone doesn't always bring it
-        // to the foreground when another file is currently selected.
-        manager.setSelectedEditor(virtualFile, "text-editor")
+        val descriptor = OpenFileDescriptor(project, virtualFile)
+        val editor = manager.openTextEditor(descriptor, true)
 
         log.info(
             "Codewalker: opened head-ref tab for $path; selected file is " +
                 "${manager.selectedFiles.firstOrNull()?.name}"
         )
 
-        // Fetch the editor instance for highlighting. By this point the tab
-        // is selected and the underlying TextEditor is available.
-        return (manager.getSelectedEditor(virtualFile) as? com.intellij.openapi.fileEditor.TextEditor)
-            ?.editor
+        return editor
     }
 
     override fun dispose() {
         scope.cancel()
         contentCache.clear()
         virtualFileCache.clear()
+        currentLightFile = null
         clearHighlight()
     }
 

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -49,6 +49,7 @@ class EditorHighlighter(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val contentCache = mutableMapOf<Pair<String, String>, ByteArray>()
+    private val virtualFileCache = mutableMapOf<Pair<String, String>, LightVirtualFile>()
     private var boundContext: BoundContext? = null
 
     fun bind(forgeContext: ForgeContext?) {
@@ -61,6 +62,7 @@ class EditorHighlighter(
             }
         }
         contentCache.clear()
+        virtualFileCache.clear()
     }
 
     fun highlightHunk(span: HunkSpan) {
@@ -218,14 +220,17 @@ class EditorHighlighter(
     }
 
     private fun openHeadRefContent(path: String, ref: String, content: ByteArray): Editor? {
-        val fileName = path.substringAfterLast('/')
-        val displayName = "$fileName @ ${ref.take(7)}"
-        val virtualFile = LightVirtualFile(
-            displayName,
-            FileTypeManager.getInstance().getFileTypeByFileName(fileName),
-            String(content, Charsets.UTF_8),
-        ).apply {
-            isWritable = false
+        val key = path to ref
+        val virtualFile = virtualFileCache.getOrPut(key) {
+            val fileName = path.substringAfterLast('/')
+            val displayName = "$fileName @ ${ref.take(7)}"
+            LightVirtualFile(
+                displayName,
+                FileTypeManager.getInstance().getFileTypeByFileName(fileName),
+                String(content, Charsets.UTF_8),
+            ).apply {
+                isWritable = false
+            }
         }
         val descriptor = OpenFileDescriptor(project, virtualFile)
         return FileEditorManager.getInstance(project).openTextEditor(descriptor, false)
@@ -234,6 +239,7 @@ class EditorHighlighter(
     override fun dispose() {
         scope.cancel()
         contentCache.clear()
+        virtualFileCache.clear()
         clearHighlight()
     }
 

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -3,7 +3,6 @@ package com.snootbeestci.codewalker.editor
 import codewalker.v1.Codewalker.ForgeContext
 import codewalker.v1.Codewalker.HunkSpan
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -50,7 +49,6 @@ class EditorHighlighter(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val contentCache = mutableMapOf<Pair<String, String>, ByteArray>()
-    private val virtualFileCache = mutableMapOf<Pair<String, String>, LightVirtualFile>()
     private var currentLightFile: LightVirtualFile? = null
     private var boundContext: BoundContext? = null
 
@@ -64,7 +62,6 @@ class EditorHighlighter(
             }
         }
         contentCache.clear()
-        virtualFileCache.clear()
         currentLightFile = null
     }
 
@@ -223,60 +220,31 @@ class EditorHighlighter(
     }
 
     private fun openHeadRefContent(path: String, ref: String, content: ByteArray): Editor? {
-        val key = path to ref
-
-        // Reuse the same LightVirtualFile identity for repeat navigation to
-        // the same (path, ref). IntelliJ tracks open tabs by file identity,
-        // so a fresh LightVirtualFile every call would produce duplicate
-        // tabs.
-        val virtualFile = virtualFileCache.getOrPut(key) {
-            val fileName = path.substringAfterLast('/')
-            val displayName = "$fileName @ ${ref.take(7)}"
-            LightVirtualFile(
-                displayName,
-                FileTypeManager.getInstance().getFileTypeByFileName(fileName),
-                String(content, Charsets.UTF_8),
-            ).apply {
-                isWritable = false
-            }
+        val fileName = path.substringAfterLast('/')
+        val displayName = "$fileName @ ${ref.take(7)}"
+        val virtualFile = LightVirtualFile(
+            displayName,
+            FileTypeManager.getInstance().getFileTypeByFileName(fileName),
+            String(content, Charsets.UTF_8),
+        ).apply {
+            isWritable = false
         }
 
         val manager = FileEditorManager.getInstance(project)
 
-        // Close the previously-opened Codewalker tab if it's a different
-        // file. IntelliJ's editor manager refuses to switch tabs between
-        // LightVirtualFiles via openTextEditor / openFile /
-        // setSelectedEditor; explicitly closing the old tab sidesteps the
-        // issue.
         val previous = currentLightFile
-        if (previous != null && previous != virtualFile) {
+        if (previous != null) {
             manager.closeFile(previous)
         }
         currentLightFile = virtualFile
 
-        // Open without requesting focus to avoid a race where IntelliJ
-        // tries to focus a LightVirtualFile editor whose
-        // preferredFocusedComponent hasn't been wired up yet (produces
-        // "preferredFocusedComponent is null" warnings and returns null
-        // from openTextEditor).
         val descriptor = OpenFileDescriptor(project, virtualFile)
         val editor = manager.openTextEditor(descriptor, /* requestFocus = */ false)
 
-        // Bring the tab to the foreground on the next EDT cycle, by which
-        // point the editor is fully constructed. setSelectedEditor with
-        // the text-editor provider id is the documented way to select a
-        // tab without focusing the inner editor component.
-        ApplicationManager.getApplication().invokeLater {
-            manager.setSelectedEditor(virtualFile, "text-editor")
-            log.info(
-                "Codewalker: deferred selection — selected file is " +
-                    "${manager.selectedFiles.firstOrNull()?.name}"
-            )
-        }
-
         log.info(
-            "Codewalker: opened head-ref tab for $path; immediate selection is " +
-                "${manager.selectedFiles.firstOrNull()?.name}"
+            "Codewalker: opened head-ref tab for $path; selected file is " +
+                "${manager.selectedFiles.firstOrNull()?.name}; " +
+                "editor is ${if (editor == null) "NULL" else "OK"}"
         )
 
         return editor
@@ -285,7 +253,6 @@ class EditorHighlighter(
     override fun dispose() {
         scope.cancel()
         contentCache.clear()
-        virtualFileCache.clear()
         currentLightFile = null
         clearHighlight()
     }

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -3,6 +3,7 @@ package com.snootbeestci.codewalker.editor
 import codewalker.v1.Codewalker.ForgeContext
 import codewalker.v1.Codewalker.HunkSpan
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -233,11 +234,25 @@ class EditorHighlighter(
             }
         }
         val descriptor = OpenFileDescriptor(project, virtualFile)
-        val editor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+        val manager = FileEditorManager.getInstance(project)
+
+        // Open synchronously without focus to avoid the LightVirtualFile race
+        // where openTextEditor tries to focus a not-yet-fully-constructed editor.
+        val editor = manager.openTextEditor(descriptor, false)
+
+        // Bring the tab to the foreground on the next EDT cycle. By that point
+        // the editor's preferredFocusedComponent is wired up. We pass
+        // focusEditor = false because we only want tab selection, not
+        // inner-component focus (which is what races on LightVirtualFile).
+        ApplicationManager.getApplication().invokeLater {
+            manager.openFile(virtualFile, /* focusEditor = */ false, /* searchForOpen = */ true)
+        }
+
         log.info(
             "Codewalker: opened head-ref tab for $path; selected file is " +
-                "${FileEditorManager.getInstance(project).selectedFiles.firstOrNull()?.name}"
+                "${manager.selectedFiles.firstOrNull()?.name}"
         )
+
         return editor
     }
 

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -232,8 +233,15 @@ class EditorHighlighter(
                 isWritable = false
             }
         }
-        val descriptor = OpenFileDescriptor(project, virtualFile)
-        return FileEditorManager.getInstance(project).openTextEditor(descriptor, false)
+        val manager = FileEditorManager.getInstance(project)
+        // openFile selects the tab without focusing the inner editor component,
+        // avoiding the LightVirtualFile focus race while still bringing the
+        // correct tab to the foreground.
+        manager.openFile(virtualFile, /* focusEditor = */ false, /* searchForOpen = */ true)
+        return (manager.getSelectedEditor(virtualFile) as? TextEditor)?.editor
+            ?: manager.allEditors.filterIsInstance<TextEditor>()
+                .firstOrNull { it.file == virtualFile }
+                ?.editor
     }
 
     override fun dispose() {

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -3,6 +3,7 @@ package com.snootbeestci.codewalker.editor
 import codewalker.v1.Codewalker.ForgeContext
 import codewalker.v1.Codewalker.HunkSpan
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -223,6 +224,11 @@ class EditorHighlighter(
 
     private fun openHeadRefContent(path: String, ref: String, content: ByteArray): Editor? {
         val key = path to ref
+
+        // Reuse the same LightVirtualFile identity for repeat navigation to
+        // the same (path, ref). IntelliJ tracks open tabs by file identity,
+        // so a fresh LightVirtualFile every call would produce duplicate
+        // tabs.
         val virtualFile = virtualFileCache.getOrPut(key) {
             val fileName = path.substringAfterLast('/')
             val displayName = "$fileName @ ${ref.take(7)}"
@@ -234,24 +240,42 @@ class EditorHighlighter(
                 isWritable = false
             }
         }
+
         val manager = FileEditorManager.getInstance(project)
 
-        // Close the previously-opened Codewalker tab if it's different from
-        // the one we're about to open. IntelliJ's editor manager has issues
-        // switching tabs between LightVirtualFiles via openTextEditor /
-        // openFile / setSelectedEditor; closing the old one first sidesteps
-        // the issue.
+        // Close the previously-opened Codewalker tab if it's a different
+        // file. IntelliJ's editor manager refuses to switch tabs between
+        // LightVirtualFiles via openTextEditor / openFile /
+        // setSelectedEditor; explicitly closing the old tab sidesteps the
+        // issue.
         val previous = currentLightFile
         if (previous != null && previous != virtualFile) {
             manager.closeFile(previous)
         }
         currentLightFile = virtualFile
 
+        // Open without requesting focus to avoid a race where IntelliJ
+        // tries to focus a LightVirtualFile editor whose
+        // preferredFocusedComponent hasn't been wired up yet (produces
+        // "preferredFocusedComponent is null" warnings and returns null
+        // from openTextEditor).
         val descriptor = OpenFileDescriptor(project, virtualFile)
-        val editor = manager.openTextEditor(descriptor, true)
+        val editor = manager.openTextEditor(descriptor, /* requestFocus = */ false)
+
+        // Bring the tab to the foreground on the next EDT cycle, by which
+        // point the editor is fully constructed. setSelectedEditor with
+        // the text-editor provider id is the documented way to select a
+        // tab without focusing the inner editor component.
+        ApplicationManager.getApplication().invokeLater {
+            manager.setSelectedEditor(virtualFile, "text-editor")
+            log.info(
+                "Codewalker: deferred selection — selected file is " +
+                    "${manager.selectedFiles.firstOrNull()?.name}"
+            )
+        }
 
         log.info(
-            "Codewalker: opened head-ref tab for $path; selected file is " +
+            "Codewalker: opened head-ref tab for $path; immediate selection is " +
                 "${manager.selectedFiles.firstOrNull()?.name}"
         )
 


### PR DESCRIPTION
## Summary

Eight fixes converging on close-then-open + cache + deferred selection for `LightVirtualFile` in `EditorHighlighter.openHeadRefContent`, then commit 9 strips the cache as a diagnostic to isolate whether cached `LightVirtualFile` reuse after `closeFile` is what's breaking subsequent opens.

**Commit 1 — `fix: don't request focus when opening LightVirtualFile`** *(superseded)*
**Commit 2 — `fix: cache LightVirtualFile to prevent duplicate tabs`** — added `virtualFileCache: MutableMap<Pair<String, String>, LightVirtualFile>`; cleared in `bind()`/`dispose()`. *(removed in 9 as diagnostic)*
**Commit 3 — `fix: bring head-ref tab to foreground without focus race`** *(superseded)*
**Commit 4 — `fix: restore tab selection when opening cached LightVirtualFile`** *(superseded)*
**Commit 5 — `fix: defer LightVirtualFile tab selection to next EDT cycle`** *(superseded)*
**Commit 6 — `fix: use openFile for LightVirtualFile to handle repeat opens`** *(superseded)*
**Commit 7 — `fix: close previous LightVirtualFile tab before opening next`** — added `currentLightFile`; close-then-open.
**Commit 8 — `fix: rewrite openHeadRefContent with close-first and deferred selection`** — wholesale rewrite consolidating the close-first + deferred-selection shape with the cache.
**Commit 9 — `diag: remove LightVirtualFile cache to isolate the open failure`** — diagnostic, not a fix.

### Commit 9 details

Hypothesis: reusing a cached `LightVirtualFile` after `closeFile(previous)` is what's breaking subsequent opens. Strip the cache and construct fresh on every call to test.

- Drop the `virtualFileCache` field and its clears in `bind()`/`dispose()`.
- Drop the `ApplicationManager` import (deferred selection also removed).
- `openHeadRefContent` is now the simplest possible shape: build a fresh `LightVirtualFile`, close `currentLightFile` if any (no `previous != virtualFile` guard since every call constructs a new instance), open with `requestFocus = false`, log the result.
- Diagnostic log line includes `editor is OK|NULL` so the failure mode is unambiguous in the IDE log.
- `currentLightFile` retained for the close-first behaviour.

Repeat navigation to the same file now closes and reopens — wasteful but unambiguous for diagnosis.

### What we want to see in the log

After clicking three different files, three log lines, each showing:
- Correct file path
- Correct `selected file is …` matching that path
- `editor is OK` (not NULL)

If we see that, the cache was the problem and we'll redesign reuse (probably listening for file-close events to invalidate the cache entry).

If we still see `editor is NULL`, the bug isn't the cache and the next investigation is `LightVirtualFile` construction, file-type resolution, or whatever else changes between the working first call and the failing subsequent calls.

## Test plan

- [ ] `./gradlew check` passes
- [ ] In a multi-file review session, click three different files and capture the three log lines
- [ ] Note whether `editor is OK` or `editor is NULL` for each
- [ ] Note whether `selected file is …` matches the navigated file for each
- [ ] No `preferredFocusedComponent is null` warnings in the IDE log

## Notes

- `./gradlew check` could not be executed in the sandbox where these changes were made — `jitpack.io`, `download.jetbrains.com`, and `cache-redirector.jetbrains.com` return HTTP 403 from this environment. Please run `./gradlew check` locally before merging.
- Branch name (`claude/audit-glossary-handling-gcOiX`) does not match the PR contents — it was the branch designated by the harness for this session.
- This PR is now mid-investigation: commit 9 is diagnostic. Don't merge as-is — wait for the log results, then either restore the cache with a smarter invalidation strategy or pursue a different root cause.