### PR TITLE
fix: use FileEditorManagerImpl.openFile with close-first for LightVirtualFile

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -312,10 +312,20 @@ opening the working-tree copy unconditionally.
   over raw Swing equivalents — but verify the class is available on the plugin
   compilation classpath before using it. `com.intellij.ui.ComboBox` is a known
   example that is absent in IntelliJ 2025.1; use `javax.swing.JComboBox` instead.
-- Editor integration uses `FileEditorManager.openTextEditor()` to open files
-  and `editor.markupModel.addRangeHighlighter()` for transient highlights.
-  Always call `RangeHighlighter.dispose()` to clean up — never let highlights
-  accumulate across sessions.
+- Editor integration uses `FileEditorManager.openTextEditor()` for real
+  `VirtualFile`s and `editor.markupModel.addRangeHighlighter()` for
+  transient highlights. Always call `RangeHighlighter.dispose()` to clean
+  up — never let highlights accumulate across sessions.
+- For `LightVirtualFile` head-ref tabs the highlighter casts to
+  `FileEditorManagerImpl` and calls the impl-level `openFile` with
+  `FileEditorOpenOptions(reuseOpen = true, isSingletonEditorInWindow = true)`
+  — same shape as the platform's own `DiffEditorTabFilesManagerImpl`. The
+  public `openTextEditor` returns `null` on the second `LightVirtualFile`
+  open in a session, and `isSingletonEditorInWindow` requires the previous
+  singleton to be closed before opening the next, so `EditorHighlighter`
+  caches the `LightVirtualFile` per `(path, ref)` and tracks the current
+  one to close it on switch (skipping close-reopen when the new file is
+  the same instance, so highlight updates within a file don't flicker).
 - Index lookups (`FilenameIndex`, `ProjectFileIndex`, PSI traversal etc.)
   require a read action — wrap them in `ReadAction.compute { ... }` when
   called from the EDT or a coroutine, otherwise IntelliJ throws

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -14,6 +14,9 @@ import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl
+import com.intellij.openapi.fileEditor.impl.FileEditorOpenOptions
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -49,6 +52,8 @@ class EditorHighlighter(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val contentCache = mutableMapOf<Pair<String, String>, ByteArray>()
+    private val virtualFileCache = mutableMapOf<Pair<String, String>, LightVirtualFile>()
+    private var currentLightFile: LightVirtualFile? = null
     private var boundContext: BoundContext? = null
 
     fun bind(forgeContext: ForgeContext?) {
@@ -61,6 +66,8 @@ class EditorHighlighter(
             }
         }
         contentCache.clear()
+        virtualFileCache.clear()
+        currentLightFile = null
     }
 
     fun highlightHunk(span: HunkSpan) {
@@ -218,22 +225,62 @@ class EditorHighlighter(
     }
 
     private fun openHeadRefContent(path: String, ref: String, content: ByteArray): Editor? {
-        val fileName = path.substringAfterLast('/')
-        val displayName = "$fileName @ ${ref.take(7)}"
-        val virtualFile = LightVirtualFile(
-            displayName,
-            FileTypeManager.getInstance().getFileTypeByFileName(fileName),
-            String(content, Charsets.UTF_8),
-        ).apply {
-            isWritable = false
+        val key = path to ref
+
+        // Reuse the same LightVirtualFile identity for repeat navigation to
+        // the same (path, ref). reuseOpen below matches files by .equals,
+        // so caching the file makes repeat clicks land on the same tab
+        // instead of opening a new one.
+        val virtualFile = virtualFileCache.getOrPut(key) {
+            val fileName = path.substringAfterLast('/')
+            val displayName = "$fileName @ ${ref.take(7)}"
+            LightVirtualFile(
+                displayName,
+                FileTypeManager.getInstance().getFileTypeByFileName(fileName),
+                String(content, Charsets.UTF_8),
+            ).apply {
+                isWritable = false
+            }
         }
-        val descriptor = OpenFileDescriptor(project, virtualFile)
-        return FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+
+        val manager = FileEditorManager.getInstance(project) as FileEditorManagerImpl
+
+        // isSingletonEditorInWindow allows only one singleton tab per window.
+        // Close the previous one before opening a new one, otherwise openFile
+        // returns FileEditorComposite.EMPTY because the slot is occupied.
+        // The previous != virtualFile guard handles same-file re-navigation
+        // (different hunks within one file) — don't close-and-reopen, let
+        // reuseOpen reselect the existing tab.
+        val previous = currentLightFile
+        if (previous != null && previous != virtualFile) {
+            manager.closeFile(previous)
+        }
+        currentLightFile = virtualFile
+
+        // Cast to FileEditorManagerImpl to access the impl-level openFile
+        // overload. This is the same call shape the platform's own diff
+        // viewer (DiffEditorTabFilesManagerImpl.showDiffFile) uses for
+        // non-physical files. The public FileEditorManager.openTextEditor
+        // returns null on the second LightVirtualFile open in the same
+        // session.
+        val composite = manager.openFile(
+            file = virtualFile,
+            window = null,
+            options = FileEditorOpenOptions(
+                reuseOpen = true,
+                isSingletonEditorInWindow = true,
+                requestFocus = false,
+            ),
+        )
+
+        return composite.allEditors.filterIsInstance<TextEditor>().firstOrNull()?.editor
     }
 
     override fun dispose() {
         scope.cancel()
         contentCache.clear()
+        virtualFileCache.clear()
+        currentLightFile = null
         clearHighlight()
     }
 


### PR DESCRIPTION
## Summary

`isSingletonEditorInWindow = true` allows only one singleton editor per window. The first call to `openFile` succeeds; subsequent calls return `FileEditorComposite.EMPTY` because the slot is occupied, leaving the editor pane stuck on the first opened file. The public `FileEditorManager.openTextEditor` also returns `null` on the second `LightVirtualFile` open in a session.

This PR adopts the platform diff viewer's pattern (`FileEditorManagerImpl.openFile` with `FileEditorOpenOptions`) and closes the previous singleton before opening the next.

## Changes

- `EditorHighlighter.openHeadRefContent` rewritten to:
  - Cache `LightVirtualFile` per `(path, ref)` so repeat navigation reuses the same identity (matches `reuseOpen` by `.equals`).
  - Track the current singleton in `currentLightFile`; close it before opening a new one.
  - Skip close-reopen when the new file is the same instance, so within-file hunk switches don't flicker.
  - Cast to `FileEditorManagerImpl` and call the impl-level `openFile` with `FileEditorOpenOptions(reuseOpen = true, isSingletonEditorInWindow = true, requestFocus = false)`.
- New fields `virtualFileCache` and `currentLightFile` cleared in `bind()` and `dispose()`.
- New imports: `TextEditor`, `FileEditorManagerImpl`, `FileEditorOpenOptions`.
- Briefing updated: editor-integration rule now describes both paths — public `openTextEditor` for real `VirtualFile`s, impl-level `openFile` with close-first for `LightVirtualFile` singletons, and explains why the impl-level call is necessary.

## Test plan

- [ ] `./gradlew check` passes (could not run in this sandbox — JetBrains repos return HTTP 403 from the build environment, so verify locally)
- [ ] `./gradlew runIde`, open a session with multiple files, click file A → tab `A @ <sha>` opens with highlight
- [ ] Click file B → A's tab closes, B's tab opens in the same slot with highlight
- [ ] Click A again → B's tab closes, A's tab opens
- [ ] Click a different hunk within A → tab stays, highlight updates with no close-reopen flicker
- [ ] No `preferredFocusedComponent is null` warnings in the log
- [ ] No `could not open an editor` debug lines
- [ ] Any non-Codewalker file open before the session is left untouched in its own tab

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfWRQkDa4B6TRry9cMNnQF)_