### PR TITLE
refactor: derive step list order from forge_context.files

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -129,6 +129,21 @@ when `complete.hasSummary()` is true, otherwise passes `null` (which clears
 the table). `SessionPanel.clearNarration` clears both the narration pane
 and the summary table.
 
+The file/step list is built by joining `ReviewReady.forge_context.files`
+(canonical file order, deterministic, aligned with backend Forward
+navigation) with `ReviewReady.steps` (grouped by `hunk_span.file_path`,
+sorted within each file by `hunk_span.new_start`). The plugin does not
+rely on the wire order of `ReviewReady.steps` for display purposes —
+that field's order is treated as unspecified, even though the current
+backend emits it in Forward order as of v0.6.1. Steps whose
+`hunk_span.file_path` is not present in `forge_context.files` are
+dropped from the rendered list and logged as orphans.
+
+`NavigationController.findNextStep` / `findPreviousStep` walk the same
+display order rather than the wire order of `controller.steps`, so the
+pre-fetch highlight always lands on the file the backend's Forward RPC
+will actually open next.
+
 The summary table colour-codes three signal fields:
 
 - `breaking` — green (No), red (Yes)
@@ -325,6 +340,10 @@ opening the working-tree copy unconditionally.
   via `Disposer.register(parent, child)` so cancellation cascades
   automatically — manual `child.dispose()` calls in a parent's
   `dispose()` are a code smell.
+- Display order of repeated proto fields is the server's choice. Plugin
+  code that needs a specific order constructs it locally from structured
+  fields (file lists, line numbers) rather than depending on the wire
+  order of unstructured `repeated` fields.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
@@ -6,6 +6,7 @@ import codewalker.v1.Codewalker.Step
 import codewalker.v1.navigateRequest
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
 import com.snootbeestci.codewalker.toolwindow.SessionPanel
+import com.snootbeestci.codewalker.toolwindow.displayOrderedSteps
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -49,14 +50,21 @@ class NavigationController(
         })
     }
 
+    private fun orderedSteps(): List<Step> {
+        val files = controller.forgeContext?.filesList.orEmpty()
+        return displayOrderedSteps(controller.steps, files)
+    }
+
     private fun findNextStep(): Step? {
-        val currentIdx = controller.steps.indexOfFirst { it.id == controller.currentStepId }
-        return controller.steps.getOrNull(currentIdx + 1)
+        val ordered = orderedSteps()
+        val currentIdx = ordered.indexOfFirst { it.id == controller.currentStepId }
+        return ordered.getOrNull(currentIdx + 1)
     }
 
     private fun findPreviousStep(): Step? {
-        val currentIdx = controller.steps.indexOfFirst { it.id == controller.currentStepId }
-        return controller.steps.getOrNull(currentIdx - 1)
+        val ordered = orderedSteps()
+        val currentIdx = ordered.indexOfFirst { it.id == controller.currentStepId }
+        return ordered.getOrNull(currentIdx - 1)
     }
 
     private fun navigate(request: NavigateRequest) {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -1,6 +1,7 @@
 package com.snootbeestci.codewalker.toolwindow
 
 import codewalker.v1.Codewalker.EdgeLabel
+import codewalker.v1.Codewalker.ReviewFile
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.Codewalker.StepComplete
 import com.intellij.openapi.Disposable
@@ -29,6 +30,63 @@ import javax.swing.JPanel
 import javax.swing.JTextPane
 import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
+
+internal sealed class StepListItem {
+    data class Subtitle(val text: String) : StepListItem()
+    data class Header(val filePath: String) : StepListItem()
+    data class StepRow(val stepId: String, val label: String) : StepListItem()
+}
+
+internal fun orderStepsByFile(
+    steps: List<Step>,
+    files: List<ReviewFile>,
+): List<Pair<String, List<Step>>> {
+    val stepsByFile = steps.groupBy { it.hunkSpan.filePath }
+    return files
+        .map { file ->
+            file.filePath to stepsByFile[file.filePath].orEmpty()
+                .sortedBy { it.hunkSpan.newStart }
+        }
+        .filter { it.second.isNotEmpty() }
+}
+
+internal fun displayOrderedSteps(steps: List<Step>, files: List<ReviewFile>): List<Step> =
+    orderStepsByFile(steps, files).flatMap { it.second }
+
+internal fun orphanedStepPaths(steps: List<Step>, files: List<ReviewFile>): Set<String> {
+    val filePaths = files.map { it.filePath }.toSet()
+    return steps.map { it.hunkSpan.filePath }.toSet() - filePaths
+}
+
+internal fun buildStepListItems(
+    steps: List<Step>,
+    files: List<ReviewFile>,
+): List<StepListItem> {
+    val grouped = orderStepsByFile(steps, files)
+    if (grouped.isEmpty()) return emptyList()
+
+    val items = mutableListOf<StepListItem>()
+    val prefix = longestCommonDirectoryPrefix(grouped.map { it.first })
+    if (prefix.isNotEmpty()) {
+        items.add(StepListItem.Subtitle(prefix))
+    }
+    for ((path, fileSteps) in grouped) {
+        val displayPath = if (prefix.isNotEmpty() && path.startsWith(prefix)) {
+            path.removePrefix(prefix)
+        } else {
+            path
+        }
+        items.add(StepListItem.Header(displayPath))
+        fileSteps.forEachIndexed { index, step ->
+            val span = step.hunkSpan
+            val end = span.newStart + maxOf(span.newLines, 1) - 1
+            val rangeLabel = "${span.newStart}–$end"
+            val label = step.label.ifEmpty { "Hunk ${index + 1} (lines $rangeLabel)" }
+            items.add(StepListItem.StepRow(step.id, label))
+        }
+    }
+    return items
+}
 
 internal fun longestCommonDirectoryPrefix(paths: List<String>): String {
     if (paths.isEmpty()) return ""
@@ -183,7 +241,7 @@ class SessionPanel(
         highlighter.bind(controller.forgeContext)
         updateLanguageBadge(controller)
         updateLevelPips(controller.effectiveLevel)
-        populateStepList(controller.steps)
+        populateStepList(controller.steps, controller.forgeContext?.filesList.orEmpty())
         updateBreadcrumb(listOf(controller.forgeContext?.prTitle?.takeIf { it.isNotEmpty() } ?: "Review"))
         clearNarration()
         backButton.isEnabled = false
@@ -244,34 +302,16 @@ class SessionPanel(
         }
     }
 
-    private fun populateStepList(steps: List<Step>) {
+    private fun populateStepList(steps: List<Step>, files: List<ReviewFile>) {
         stepListModel.clear()
-        val grouped = LinkedHashMap<String, MutableList<Step>>()
-        for (step in steps) {
-            val path = step.hunkSpan.filePath
-            if (path.isEmpty()) {
-                log.warn("Hunk step has empty filePath: id=${step.id}")
-            }
-            grouped.getOrPut(path.ifEmpty { "(unknown)" }) { mutableListOf() }.add(step)
+        val orphaned = orphanedStepPaths(steps, files)
+        if (orphaned.isNotEmpty()) {
+            log.warn(
+                "Codewalker: ${orphaned.size} step(s) reference files not in forge_context: $orphaned"
+            )
         }
-        val prefix = longestCommonDirectoryPrefix(grouped.keys.toList())
-        if (prefix.isNotEmpty()) {
-            stepListModel.addElement(StepListItem.Subtitle(prefix))
-        }
-        for ((path, fileSteps) in grouped) {
-            val displayPath = if (prefix.isNotEmpty() && path.startsWith(prefix)) {
-                path.removePrefix(prefix)
-            } else {
-                path
-            }
-            stepListModel.addElement(StepListItem.Header(displayPath))
-            fileSteps.forEachIndexed { index, step ->
-                val span = step.hunkSpan
-                val end = span.newStart + maxOf(span.newLines, 1) - 1
-                val rangeLabel = "${span.newStart}–$end"
-                val label = step.label.ifEmpty { "Hunk ${index + 1} (lines $rangeLabel)" }
-                stepListModel.addElement(StepListItem.StepRow(step.id, label))
-            }
+        for (item in buildStepListItems(steps, files)) {
+            stepListModel.addElement(item)
         }
     }
 
@@ -284,12 +324,6 @@ class SessionPanel(
     private fun updateLevelPips(level: Int) {
         val capped = level.coerceIn(0, MAX_LEVEL)
         levelLabel.text = "●".repeat(capped) + "○".repeat(MAX_LEVEL - capped)
-    }
-
-    private sealed class StepListItem {
-        data class Subtitle(val text: String) : StepListItem()
-        data class Header(val filePath: String) : StepListItem()
-        data class StepRow(val stepId: String, val label: String) : StepListItem()
     }
 
     private class StepListRenderer : javax.swing.ListCellRenderer<StepListItem> {

--- a/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanelTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanelTest.kt
@@ -1,9 +1,140 @@
 package com.snootbeestci.codewalker.toolwindow
 
+import codewalker.v1.Codewalker.HunkSpan
+import codewalker.v1.Codewalker.ReviewFile
+import codewalker.v1.Codewalker.Step
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SessionPanelTest {
+
+    private fun step(id: String, filePath: String, newStart: Int, newLines: Int = 1): Step =
+        Step.newBuilder()
+            .setId(id)
+            .setHunkSpan(
+                HunkSpan.newBuilder()
+                    .setFilePath(filePath)
+                    .setNewStart(newStart)
+                    .setNewLines(newLines)
+                    .build()
+            )
+            .build()
+
+    private fun file(path: String): ReviewFile =
+        ReviewFile.newBuilder().setFilePath(path).build()
+
+    private fun headerOrder(items: List<StepListItem>): List<String> =
+        items.filterIsInstance<StepListItem.Header>().map { it.filePath }
+
+    private fun rowSteps(items: List<StepListItem>): List<String> =
+        items.filterIsInstance<StepListItem.StepRow>().map { it.stepId }
+
+    @Test
+    fun `files render in forge_context order, not steps wire order`() {
+        val steps = listOf(
+            step("hunk:b.kt:10", "b.kt", 10),
+            step("hunk:a.kt:5", "a.kt", 5),
+            step("hunk:b.kt:30", "b.kt", 30),
+        )
+        val files = listOf(file("a.kt"), file("b.kt"))
+
+        val items = buildStepListItems(steps, files)
+
+        assertEquals(listOf("a.kt", "b.kt"), headerOrder(items))
+    }
+
+    @Test
+    fun `hunks within a file are sorted by new_start`() {
+        val steps = listOf(
+            step("hunk:a.kt:30", "a.kt", 30),
+            step("hunk:a.kt:5", "a.kt", 5),
+            step("hunk:a.kt:15", "a.kt", 15),
+        )
+        val files = listOf(file("a.kt"))
+
+        val items = buildStepListItems(steps, files)
+
+        assertEquals(
+            listOf("hunk:a.kt:5", "hunk:a.kt:15", "hunk:a.kt:30"),
+            rowSteps(items),
+        )
+    }
+
+    @Test
+    fun `steps without a matching forge_context file are dropped from rendering`() {
+        val steps = listOf(
+            step("hunk:a.kt:5", "a.kt", 5),
+            step("hunk:ghost.kt:1", "ghost.kt", 1),
+        )
+        val files = listOf(file("a.kt"))
+
+        val items = buildStepListItems(steps, files)
+
+        assertEquals(listOf("a.kt"), headerOrder(items))
+        assertEquals(listOf("hunk:a.kt:5"), rowSteps(items))
+    }
+
+    @Test
+    fun `orphaned step paths are reported`() {
+        val steps = listOf(
+            step("hunk:a.kt:5", "a.kt", 5),
+            step("hunk:ghost.kt:1", "ghost.kt", 1),
+        )
+        val files = listOf(file("a.kt"))
+
+        val orphans = orphanedStepPaths(steps, files)
+
+        assertEquals(setOf("ghost.kt"), orphans)
+    }
+
+    @Test
+    fun `display order walks files then sorted hunks`() {
+        val steps = listOf(
+            step("hunk:b.kt:10", "b.kt", 10),
+            step("hunk:a.kt:30", "a.kt", 30),
+            step("hunk:a.kt:5", "a.kt", 5),
+            step("hunk:b.kt:1", "b.kt", 1),
+        )
+        val files = listOf(file("a.kt"), file("b.kt"))
+
+        val ordered = displayOrderedSteps(steps, files)
+
+        assertEquals(
+            listOf("hunk:a.kt:5", "hunk:a.kt:30", "hunk:b.kt:1", "hunk:b.kt:10"),
+            ordered.map { it.id },
+        )
+    }
+
+    @Test
+    fun `files with no steps are skipped from headers`() {
+        val steps = listOf(step("hunk:a.kt:5", "a.kt", 5))
+        val files = listOf(file("a.kt"), file("empty.kt"))
+
+        val items = buildStepListItems(steps, files)
+
+        assertEquals(listOf("a.kt"), headerOrder(items))
+    }
+
+    @Test
+    fun `common directory prefix is emitted as a subtitle`() {
+        val steps = listOf(
+            step("hunk:1", "src/main/A.kt", 5),
+            step("hunk:2", "src/main/B.kt", 5),
+        )
+        val files = listOf(file("src/main/A.kt"), file("src/main/B.kt"))
+
+        val items = buildStepListItems(steps, files)
+
+        val subtitles = items.filterIsInstance<StepListItem.Subtitle>()
+        assertEquals(listOf("src/main/"), subtitles.map { it.text })
+        assertEquals(listOf("A.kt", "B.kt"), headerOrder(items))
+    }
+
+    @Test
+    fun `empty inputs render to no items`() {
+        assertTrue(buildStepListItems(emptyList(), emptyList()).isEmpty())
+    }
 
     @Test
     fun `empty list returns empty prefix`() {


### PR DESCRIPTION
Closes #49.

## Summary

The session-pane file/step list previously iterated `ReviewReady.stepsList` and grouped by `hunkSpan.filePath` into a `LinkedHashMap`, so the visible order was wire order of the unstructured `steps` field. This change computes display order from structured fields the backend already provides:

- File order comes from `ReviewReady.forge_context.files` (canonical file order, deterministic, aligned with backend Forward navigation).
- Hunk order within a file comes from `Step.hunk_span.new_start`.

## Changes

- `SessionPanel.kt`
  - Extract `StepListItem` to package-internal scope so it can be tested directly.
  - Add pure helpers `orderStepsByFile`, `displayOrderedSteps`, `orphanedStepPaths`, and `buildStepListItems` that compute the display order from `(steps, forge_context.files)`.
  - Rewrite `populateStepList` to take `files: List<ReviewFile>` and delegate to `buildStepListItems`. Steps whose `hunk_span.file_path` is not in `forge_context.files` are dropped from the rendered list and logged as orphans.
  - `bind` passes `controller.forgeContext?.filesList.orEmpty()` to `populateStepList`.

- `NavigationController.kt`
  - `findNextStep` / `findPreviousStep` now walk the same display order rather than the wire order of `controller.steps`. This is still a pre-fetch heuristic — the backend's Forward RPC remains authoritative — but the heuristic now agrees with the backend's order by construction.

- `SessionPanelTest.kt`
  - New tests cover file-order from `forge_context.files`, hunk sort by `new_start`, orphan dropping, orphan reporting, the combined `displayOrderedSteps` walk, files with no steps, and common-prefix subtitle emission.

- `codewalker-intellij-briefing.md`
  - Document the new ordering contract and the rule that wire order of `repeated` fields is not relied on for display.

## Test plan

- [ ] `./gradlew check` passes locally
- [ ] New `populateStepList` tests pass
- [ ] Existing `longestCommonDirectoryPrefix` tests still pass

> Note: `./gradlew check` could not be executed in this sandbox — JetBrains artifact downloads (`download.jetbrains.com`, `cache-redirector.jetbrains.com`, `jitpack.io/idea/...`) returned 403 from the sandbox network. The change is verified by inspection; please confirm `./gradlew check` locally before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERxWZXjFZZk1NVQrnmtnFE)_