### PR TITLE
feat: checkout PR branch on session start with stash prompt

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -272,38 +272,55 @@ path elsewhere in the plugin — host parsing lives in one place.
 
 ## Review session file display
 
-Review session highlights are applied against the PR's head-ref content,
-not the working-tree copy. The plugin fetches file content via the
-backend's `FetchFileAtRef` RPC, which wraps the same forge handler used
-by session opening.
+When a review session starts, the plugin checks out the PR's head branch
+in the user's working tree. All files opened during the session are real
+`VirtualFile`s aligned with the diff — full IDE features (Find Usages,
+run configs, navigation) work as normal.
 
-Resolution order:
+Session-start flow (in `ReviewSessionController.openReview`, after the
+backend's `OpenReviewSession` returns `ReviewReady` and before the panel
+is switched to the session card):
 
-1. Fetch the head-ref content (cached per session, keyed by path+ref)
-2. If the working-tree copy exists and is byte-equal, open the real
-   `VirtualFile` — preserves IDE features like Find Usages and run
-   configurations
-3. Otherwise open a read-only `LightVirtualFile` named
-   `<filename> @ <short-ref>` showing the head-ref content
+1. If the working tree is dirty, show a Stash/Cancel modal
+   (`DirtyTreeDialog`). Cancel aborts the session; Stash creates a
+   tagged stash and proceeds.
+2. Fetch from `origin` via a `GitLineHandler` invocation of
+   `git fetch origin` (origin only — fork PRs are not supported in
+   this version and surface a clear "branch not on origin" error).
+3. Check out the branch via `GitBrancher.checkout(branch, false, repos)`
+   — branch checkout, not detached HEAD.
+4. Switch the tool window to the session card and start narration.
 
-This matches the diff's line numbers to the displayed content
-unconditionally. Working-tree drift no longer produces silent
-misalignment.
+Stash entries are tagged `codewalker-<sessionTag>` so they can be
+distinguished from user-created stashes. On every session start the
+plugin scans for codewalker-tagged stashes via `git stash list` and
+logs a warning (informational only) listing any leftovers from
+sessions that did not clean up. Automatic restoration is tracked
+separately.
 
-Fetch failures fall back to the working-tree copy with a user-visible
-status message; the user is never silently shown the wrong content.
-`NOT_FOUND` from the backend is treated as "file genuinely doesn't
-exist at the head ref" — no fallback, the highlight is cleared and
-the user is notified.
+Concurrent sessions are not supported in this version; the plugin
+refuses a second `openReview` call while one is active via an
+`AtomicBoolean` on the controller. This is a stopgap until proper
+session lifecycle exists.
 
-`EditorHighlighter` owns its own `CoroutineScope` (IO dispatcher,
-`SupervisorJob`) and is registered via `Disposer.register(parent, child)`
-from `SessionPanel`. The scope is cancelled and the per-session content
-cache cleared on dispose. `SessionPanel.bind` calls `highlighter.bind`
-with the active session's `ForgeContext` so the highlighter can resolve
-`(host, owner, repo, headRef)` for `FetchFileAtRef` calls. Without a
-bound context the highlighter logs and returns — it never falls back to
-opening the working-tree copy unconditionally.
+All git operations are wrapped in `CodewalkerGitOps`
+(project-scoped). Operations are exposed as plain or `suspend`
+functions over Git4Idea APIs: `GitRepositoryManager` and
+`ChangeListManager` for dirty detection, `GitBrancher` for the
+checkout (wrapped in `suspendCancellableCoroutine` so the suspend
+function resumes when the AWT-later callback fires), and
+`GitLineHandler` invoked through `Git.getInstance().runCommand` for
+`stash push`, `stash list`, and `fetch origin`. Failures throw
+`GitOperationException`, which the controller surfaces verbatim to
+the user.
+
+The legacy `EditorHighlighter` `FetchFileAtRef`-based fallback (head-ref
+content fetched over gRPC and rendered in a `LightVirtualFile` when the
+working tree was out of sync) is no longer the primary path — once the
+PR branch is checked out, the working-tree copy will match by
+construction. The highlighter retains the fetch-and-compare logic as a
+safety net for projects without a git repository or when checkout was
+skipped.
 
 ---
 
@@ -344,6 +361,13 @@ opening the working-tree copy unconditionally.
   code that needs a specific order constructs it locally from structured
   fields (file lists, line numbers) rather than depending on the wire
   order of unstructured `repeated` fields.
+- Use Git4Idea APIs for all git operations. Don't shell out to `git`
+  directly via `ProcessBuilder`/`Runtime.exec`. Operations needed today
+  (dirty detection, stash save, branch fetch, branch checkout, stash
+  list) are reachable via `GitRepositoryManager`, `ChangeListManager`,
+  `GitBrancher`, and `GitLineHandler` invoked through
+  `Git.getInstance().runCommand`. All git operations belong in
+  `CodewalkerGitOps` rather than being scattered across controllers.
 
 ### Build
 - `./gradlew runIde` — launches a sandboxed IDE with the plugin installed

--- a/src/main/kotlin/com/snootbeestci/codewalker/git/CodewalkerGitOps.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/git/CodewalkerGitOps.kt
@@ -1,0 +1,111 @@
+package com.snootbeestci.codewalker.git
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.changes.ChangeListManager
+import git4idea.branch.GitBrancher
+import git4idea.commands.Git
+import git4idea.commands.GitCommand
+import git4idea.commands.GitLineHandler
+import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryManager
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+class GitOperationException(message: String) : Exception(message)
+
+/**
+ * Wraps the Git4Idea operations needed by the Codewalker session lifecycle:
+ * dirty-tree detection, stash creation, fetch, branch checkout and stash
+ * discovery. All operations are project-scoped.
+ *
+ * Only Git4Idea APIs are used. The plugin does not shell out to `git` directly.
+ */
+class CodewalkerGitOps(private val project: Project) {
+
+    private val log = Logger.getInstance(CodewalkerGitOps::class.java)
+
+    fun firstRepository(): GitRepository? =
+        GitRepositoryManager.getInstance(project).repositories.firstOrNull()
+
+    fun isWorkingTreeDirty(repo: GitRepository): Boolean {
+        val tracked = ChangeListManager.getInstance(project).allChanges
+        val untracked = repo.untrackedFilesHolder.retrieveUntrackedFilePaths()
+        return tracked.isNotEmpty() || untracked.isNotEmpty()
+    }
+
+    fun stashChanges(repo: GitRepository, message: String) {
+        val handler = GitLineHandler(project, repo.root, GitCommand.STASH)
+        handler.addParameters("push", "--include-untracked", "-m", message)
+        val result = Git.getInstance().runCommand(handler)
+        if (!result.success()) {
+            throw GitOperationException(
+                "git stash failed: ${result.errorOutputAsJoinedString.ifBlank { "unknown error" }}"
+            )
+        }
+        repo.update()
+    }
+
+    fun fetchHeadRef(repo: GitRepository, headRef: String) {
+        val handler = GitLineHandler(project, repo.root, GitCommand.FETCH)
+        handler.addParameters("origin")
+        val result = Git.getInstance().runCommand(handler)
+        if (!result.success()) {
+            throw GitOperationException(
+                "git fetch origin failed: ${result.errorOutputAsJoinedString.ifBlank { "unknown error" }}"
+            )
+        }
+        repo.update()
+        val found = repo.branches.localBranches.any { it.name == headRef } ||
+            repo.branches.remoteBranches.any { it.nameForRemoteOperations == headRef }
+        if (!found) {
+            throw GitOperationException(
+                "Branch '$headRef' is not on origin. Pull requests from forks " +
+                    "are not supported in this version."
+            )
+        }
+    }
+
+    suspend fun checkoutBranch(repo: GitRepository, branchName: String) {
+        suspendCancellableCoroutine { cont ->
+            GitBrancher.getInstance(project).checkout(
+                branchName,
+                false,
+                listOf(repo),
+            ) {
+                cont.resume(Unit)
+            }
+        }
+    }
+
+    /**
+     * Returns the messages of stash entries whose message starts with the
+     * codewalker tag. Used to surface leftovers from sessions that did not
+     * clean up after themselves.
+     */
+    fun findCodewalkerStashes(repo: GitRepository): List<String> {
+        val handler = GitLineHandler(project, repo.root, GitCommand.STASH)
+        handler.addParameters("list", "--format=%gd %s")
+        val result = Git.getInstance().runCommand(handler)
+        if (!result.success()) {
+            log.debug("Codewalker: git stash list failed: ${result.errorOutputAsJoinedString}")
+            return emptyList()
+        }
+        return filterCodewalkerStashes(result.output)
+    }
+
+    companion object {
+        const val CODEWALKER_STASH_TAG = "codewalker-"
+
+        fun stashMessage(sessionTag: String): String = "$CODEWALKER_STASH_TAG$sessionTag"
+
+        /**
+         * Pure helper extracted from [findCodewalkerStashes] for unit testing.
+         * Given the raw lines from `git stash list --format=%gd %s`, returns
+         * only those that came from a Codewalker session.
+         */
+        internal fun filterCodewalkerStashes(lines: List<String>): List<String> =
+            lines.filter { it.contains(CODEWALKER_STASH_TAG) }
+    }
+}
+

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/DirtyTreeDialog.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/DirtyTreeDialog.kt
@@ -1,0 +1,38 @@
+package com.snootbeestci.codewalker.session
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Modal prompt shown when the working tree is dirty at the start of a
+ * review session. The user picks between stashing their changes (OK) or
+ * cancelling the session (Cancel). [showAndGet] returns true on stash.
+ */
+class DirtyTreeDialog(project: Project, private val branchName: String) : DialogWrapper(project) {
+
+    init {
+        title = "Working tree has uncommitted changes"
+        setOKButtonText("Stash and continue")
+        setCancelButtonText("Cancel")
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel(BorderLayout())
+        panel.border = JBUI.Borders.empty(8)
+        val label = JBLabel(
+            "<html>Codewalker will check out the PR branch <b>$branchName</b> so the editor " +
+                "shows the exact code being reviewed.<br>" +
+                "Your current changes need to be set aside first.</html>"
+        )
+        panel.add(label, BorderLayout.CENTER)
+        panel.preferredSize = Dimension(460, 90)
+        return panel
+    }
+}

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -6,8 +6,11 @@ import codewalker.v1.Codewalker.GlossaryTerm
 import codewalker.v1.Codewalker.SessionEvent
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.openReviewSessionRequest
+import com.intellij.openapi.diagnostic.Logger
 import com.snootbeestci.codewalker.forge.HostNormalizer
 import com.snootbeestci.codewalker.forge.TokenStore
+import com.snootbeestci.codewalker.git.CodewalkerGitOps
+import com.snootbeestci.codewalker.git.GitOperationException
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
 import com.snootbeestci.codewalker.toolwindow.CodewalkerPanel
 import kotlinx.coroutines.CancellationException
@@ -18,6 +21,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
 
 class ReviewSessionController(private val panel: CodewalkerPanel) {
 
@@ -28,8 +32,11 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
     var forgeContext: ForgeContext? = null
     var effectiveLevel: Int = 6
 
+    private val log = Logger.getInstance(ReviewSessionController::class.java)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var sessionJob: Job? = null
+    private val sessionActive = AtomicBoolean(false)
+    private val gitOps: CodewalkerGitOps = CodewalkerGitOps(panel.project)
 
     init {
         panel.loadingPanel.cancelButton.addActionListener { cancel() }
@@ -39,10 +46,18 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
     }
 
     private fun openReview(url: String, level: String) {
+        if (!sessionActive.compareAndSet(false, true)) {
+            panel.showError("A Codewalker session is already active. Close it before starting another.")
+            return
+        }
+
         panel.idlePanel.clearError()
         panel.showLoading()
 
+        warnAboutLeftoverStashes()
+
         sessionJob = scope.launch {
+            var sessionStarted = false
             try {
                 val stub = CodewalkerClient.getInstance().getStub() ?: run {
                     withContext(Dispatchers.Main) { panel.showError("Not connected to backend") }
@@ -89,6 +104,17 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                             glossary = ready.glossaryList
                             forgeContext = if (ready.hasForgeContext()) ready.forgeContext else null
                             effectiveLevel = ready.effectiveLevel
+
+                            val ctx = forgeContext
+                            if (ctx == null || ctx.headRef.isEmpty()) {
+                                log.info("Codewalker: no head ref in forge context, skipping working-tree checkout")
+                            } else if (!prepareWorkingTree(ctx.headRef, sessionId ?: ready.sessionId)) {
+                                // Error has already been surfaced; abort the
+                                // upstream stream so this coroutine ends and
+                                // releases the sessionActive gate.
+                                throw SessionPreparationAbort()
+                            }
+                            sessionStarted = true
                             withContext(Dispatchers.Main) { panel.showSession() }
                         }
                         SessionEvent.EventCase.ERROR -> {
@@ -100,10 +126,79 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                 }
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: SessionPreparationAbort) {
+                // Error was already surfaced inside prepareWorkingTree; nothing else to do.
             } catch (e: Exception) {
                 val formatted = ReviewErrorFormatter.format(e)
                 withContext(Dispatchers.Main) { panel.showError(formatted.message) }
+            } finally {
+                if (!sessionStarted) {
+                    sessionActive.set(false)
+                }
             }
+        }
+    }
+
+    /**
+     * Returns true if the session should proceed, false if it shouldn't.
+     * On false, the panel has already been navigated back to a non-loading
+     * state with an explanation.
+     */
+    private suspend fun prepareWorkingTree(headRef: String, sessionTag: String): Boolean {
+        val repo = gitOps.firstRepository()
+        if (repo == null) {
+            log.info("Codewalker: no git repository in project, skipping checkout")
+            return true
+        }
+
+        if (gitOps.isWorkingTreeDirty(repo)) {
+            val proceed = withContext(Dispatchers.Main) {
+                DirtyTreeDialog(panel.project, headRef).showAndGet()
+            }
+            if (!proceed) {
+                log.info("Codewalker: user cancelled session due to dirty working tree")
+                withContext(Dispatchers.Main) {
+                    panel.showState(CodewalkerClient.getInstance().connectionState)
+                }
+                return false
+            }
+            try {
+                gitOps.stashChanges(repo, CodewalkerGitOps.stashMessage(sessionTag))
+            } catch (e: GitOperationException) {
+                withContext(Dispatchers.Main) {
+                    panel.showError("Couldn't stash changes: ${e.message}. Session not started.")
+                }
+                return false
+            }
+        }
+
+        try {
+            gitOps.fetchHeadRef(repo, headRef)
+            gitOps.checkoutBranch(repo, headRef)
+        } catch (e: GitOperationException) {
+            withContext(Dispatchers.Main) {
+                panel.showError("Couldn't switch to branch `$headRef`: ${e.message}")
+            }
+            return false
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
+                panel.showError("Couldn't switch to branch `$headRef`: ${e.message ?: e::class.simpleName}")
+            }
+            return false
+        }
+
+        return true
+    }
+
+    private fun warnAboutLeftoverStashes() {
+        val repo = gitOps.firstRepository() ?: return
+        val leftover = gitOps.findCodewalkerStashes(repo)
+        if (leftover.isNotEmpty()) {
+            log.warn(
+                "Codewalker: found ${leftover.size} stash(es) from prior sessions: " +
+                    leftover.joinToString(separator = " | ") +
+                    ". You can restore them via Git → Uncommitted Changes → Show Stashes."
+            )
         }
     }
 
@@ -115,6 +210,7 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
     private fun cancel() {
         sessionJob?.cancel()
         sessionJob = null
+        sessionActive.set(false)
         panel.showState(CodewalkerClient.getInstance().connectionState)
     }
 
@@ -122,4 +218,6 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
         if (host.isEmpty()) return ""
         return TokenStore.getInstance().get(host) ?: ""
     }
+
+    private class SessionPreparationAbort : RuntimeException()
 }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/CodewalkerPanel.kt
@@ -10,7 +10,7 @@ import com.snootbeestci.codewalker.session.ReviewSessionController
 import java.awt.CardLayout
 import javax.swing.JPanel
 
-class CodewalkerPanel(project: Project) : Disposable {
+class CodewalkerPanel(val project: Project) : Disposable {
 
     val root: JPanel = JPanel(CardLayout())
 

--- a/src/test/kotlin/com/snootbeestci/codewalker/git/CodewalkerGitOpsTest.kt
+++ b/src/test/kotlin/com/snootbeestci/codewalker/git/CodewalkerGitOpsTest.kt
@@ -1,0 +1,47 @@
+package com.snootbeestci.codewalker.git
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CodewalkerGitOpsTest {
+
+    @Test
+    fun `stash message embeds the codewalker tag and session token`() {
+        val msg = CodewalkerGitOps.stashMessage("abc123")
+        assertEquals("codewalker-abc123", msg)
+        assertTrue(msg.startsWith(CodewalkerGitOps.CODEWALKER_STASH_TAG))
+    }
+
+    @Test
+    fun `filterCodewalkerStashes keeps only entries containing the tag`() {
+        val lines = listOf(
+            "stash@{0} On main: codewalker-abc123",
+            "stash@{1} WIP on main: hand-rolled fix",
+            "stash@{2} On feature: codewalker-deadbee",
+            "stash@{3} something else",
+        )
+        val filtered = CodewalkerGitOps.filterCodewalkerStashes(lines)
+        assertEquals(
+            listOf(
+                "stash@{0} On main: codewalker-abc123",
+                "stash@{2} On feature: codewalker-deadbee",
+            ),
+            filtered,
+        )
+    }
+
+    @Test
+    fun `filterCodewalkerStashes returns empty when no codewalker entries`() {
+        val lines = listOf(
+            "stash@{0} WIP on main: foo",
+            "stash@{1} WIP on main: bar",
+        )
+        assertEquals(emptyList<String>(), CodewalkerGitOps.filterCodewalkerStashes(lines))
+    }
+
+    @Test
+    fun `filterCodewalkerStashes returns empty for empty input`() {
+        assertEquals(emptyList<String>(), CodewalkerGitOps.filterCodewalkerStashes(emptyList()))
+    }
+}


### PR DESCRIPTION
Closes #51.

## Summary

When a review session starts, the plugin now checks out the PR's head branch in the user's working tree. All files opened during the session are real `VirtualFile`s aligned with the diff — full IDE features (Find Usages, run configs, navigation) work as normal.

## Behaviour

- **Clean working tree** — fetch `origin`, check out the head ref, then show the session card.
- **Dirty working tree** — modal `DirtyTreeDialog` (Stash and continue / Cancel). Cancel aborts the session with no git operations performed; Stash creates a `codewalker-<sessionTag>` stash entry, then proceeds.
- **Fork PRs** — refused with a clear message (`"Branch 'X' is not on origin. Pull requests from forks are not supported in this version."`).
- **Concurrent session attempt** — refused with `"A Codewalker session is already active. Close it before starting another."`. A second `openReview` call while one is in flight returns immediately and shows the message via the idle panel.
- **Leftover stash detection** — every session start scans `git stash list` for `codewalker-*` entries and logs a warning naming them so the user knows their stash is recoverable manually.

## Code structure

- `git/CodewalkerGitOps.kt` — new project-scoped wrapper. Exposes `firstRepository`, `isWorkingTreeDirty`, `stashChanges`, `fetchHeadRef`, `checkoutBranch` (`suspend`, wraps `GitBrancher.checkout`'s callback in `suspendCancellableCoroutine`), and `findCodewalkerStashes`. All operations go through Git4Idea APIs (`GitRepositoryManager`, `ChangeListManager`, `GitBrancher`, `GitLineHandler` via `Git.getInstance().runCommand`); the plugin does not shell out to `git` directly via `ProcessBuilder`.
- `session/DirtyTreeDialog.kt` — `DialogWrapper` with the agreed copy and button labels.
- `session/ReviewSessionController.kt` — adds `prepareWorkingTree`, called after `ReviewReady` arrives but before `panel.showSession()`. Failures throw a private `SessionPreparationAbort` sentinel so the gRPC `collect` ends cleanly and the session-active gate releases. Concurrent-session protection sits at `openReview` entry as an `AtomicBoolean`.
- `toolwindow/CodewalkerPanel.kt` — `project` exposed as a `val` so the controller can build `CodewalkerGitOps` and the dirty-tree dialog.

## Tests

- `git/CodewalkerGitOpsTest.kt` — covers the stash-message format and the pure stash-line filter helper. The Git4Idea-bound parts (dirty detection, fetch, checkout, dialog) are not unit-testable without an IDE runtime and are exercised manually per the issue's manual-verification list.

## Briefing

`codewalker-intellij-briefing.md` rewrites the **Review session file display** section to describe the checkout flow, and adds a Git4Idea-only rule under **Kotlin** development rules.

## Test plan

- [ ] `./gradlew check` passes in CI.
- [ ] Clean working tree → click a PR → branch is checked out, files open as real `VirtualFile`s.
- [ ] Dirty working tree → dialog appears with the right copy.
- [ ] Cancel in dialog → returns to idle, no git operations performed.
- [ ] Stash and continue → `git stash list` shows the `codewalker-<tag>` entry, branch is checked out.
- [ ] Try to start a second session while one is active → second is refused with the expected message.
- [ ] Run with a fork PR → session refuses with the unfetchable-ref message.
- [ ] Restart with an existing `codewalker-*` stash → warning appears in the IDE log.

## Commits

- `0bd4a58 feat: checkout PR branch on session start with stash prompt` — single commit covering the new utility class, dialog, controller wiring, tests, and briefing update.


---
_Generated by [Claude Code](https://claude.ai/code/session_011GTPtootpwRCd2KG6P8hgn)_