### PR TITLE
refactor: prepare working tree before opening review session

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.6.0") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.6.2") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -277,19 +277,39 @@ in the user's working tree. All files opened during the session are real
 `VirtualFile`s aligned with the diff — full IDE features (Find Usages,
 run configs, navigation) work as normal.
 
-Session-start flow (in `ReviewSessionController.openReview`, after the
-backend's `OpenReviewSession` returns `ReviewReady` and before the panel
-is switched to the session card):
+Session-start flow (in `ReviewSessionController.openReview`):
 
-1. If the working tree is dirty, show a Stash/Cancel modal
-   (`DirtyTreeDialog`). Cancel aborts the session; Stash creates a
-   tagged stash and proceeds.
-2. Fetch from `origin` via a `GitLineHandler` invocation of
-   `git fetch origin` (origin only — fork PRs are not supported in
-   this version and surface a clear "branch not on origin" error).
-3. Check out the branch via `GitBrancher.checkout(branch, false, repos)`
-   — branch checkout, not detached HEAD.
-4. Switch the tool window to the session card and start narration.
+1. The user clicks a PR row in the idle panel. The plugin has the PR's
+   url, number, title, author, and `head_ref` from the
+   `ListPullRequests` response.
+2. Working-tree preparation runs **before** any gRPC call to
+   `OpenReviewSession`:
+   - If the working tree is dirty, show a Stash/Cancel modal
+     (`DirtyTreeDialog`). Cancel aborts the session cleanly; Stash
+     creates a tagged stash and proceeds.
+   - Fetch from `origin` via a `GitLineHandler` invocation of
+     `git fetch origin` (origin only — fork PRs are not supported in
+     this version and surface a clear "branch not on origin" error).
+   - Check out the branch via `GitBrancher.checkout(branch, false, repos)`
+     — branch checkout, not detached HEAD.
+3. Only then is `OpenReviewSession` called. The backend session is
+   created only when the plugin is committed to running it — a cancel
+   in step 2 produces no server-side state, so there is no orphan
+   server session to leak until TTL eviction.
+4. On `REVIEW_READY`, switch the tool window to the session card and
+   start narration.
+
+This ordering depends on `PullRequestSummary.head_ref`, added in
+backend `v0.6.2`. If `head_ref` is empty (defensive — older backends
+or edge cases), the working-tree prep is skipped and a log line
+records the skip; the session falls back to opening without checkout.
+
+Because the prepare step runs before the session ID exists, the stash
+tag is generated locally from the head ref plus a timestamp
+(`generateStashTag` in `ReviewSessionController`). The tag still flows
+through `CodewalkerGitOps.stashMessage` so the `codewalker-` prefix is
+preserved and `findCodewalkerStashes` continues to identify these
+stashes for cleanup.
 
 Stash entries are tagged `codewalker-<sessionTag>` so they can be
 distinguished from user-created stashes. On every session start the

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -3,6 +3,7 @@ package com.snootbeestci.codewalker.session
 import codewalker.v1.Codewalker.ExperienceLevel
 import codewalker.v1.Codewalker.ForgeContext
 import codewalker.v1.Codewalker.GlossaryTerm
+import codewalker.v1.Codewalker.PullRequestSummary
 import codewalker.v1.Codewalker.SessionEvent
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.openReviewSessionRequest
@@ -41,11 +42,11 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
     init {
         panel.loadingPanel.cancelButton.addActionListener { cancel() }
         panel.idlePanel.setPullRequestClickHandler { pr ->
-            openReview(pr.url, panel.idlePanel.getExperienceLevel())
+            openReview(pr, panel.idlePanel.getExperienceLevel())
         }
     }
 
-    private fun openReview(url: String, level: String) {
+    private fun openReview(pr: PullRequestSummary, level: String) {
         if (!sessionActive.compareAndSet(false, true)) {
             panel.showError("A Codewalker session is already active. Close it before starting another.")
             return
@@ -59,6 +60,17 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
         sessionJob = scope.launch {
             var sessionStarted = false
             try {
+                // Working-tree prep happens first. If the user cancels or
+                // anything fails, we never open the gRPC stream and never
+                // create a server-side session.
+                if (pr.headRef.isNotEmpty()) {
+                    if (!prepareWorkingTree(pr.headRef)) {
+                        return@launch
+                    }
+                } else {
+                    log.info("Codewalker: no head_ref on PR ${pr.number}, skipping working-tree checkout")
+                }
+
                 val stub = CodewalkerClient.getInstance().getStub() ?: run {
                     withContext(Dispatchers.Main) { panel.showError("Not connected to backend") }
                     return@launch
@@ -70,7 +82,7 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                     else -> ExperienceLevel.EXPERIENCE_LEVEL_MID
                 }
 
-                val host = when (val parsed = HostNormalizer.fromUrlResult(url)) {
+                val host = when (val parsed = HostNormalizer.fromUrlResult(pr.url)) {
                     is HostNormalizer.UrlParseResult.Ok -> parsed.host
                     is HostNormalizer.UrlParseResult.Empty -> {
                         withContext(Dispatchers.Main) { panel.showError("Please enter a review URL.") }
@@ -83,7 +95,7 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                 }
 
                 val request = openReviewSessionRequest {
-                    this.url = url
+                    this.url = pr.url
                     experienceLevel = expLevel
                     forgeToken = resolveForgeToken(host)
                 }
@@ -104,16 +116,6 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                             glossary = ready.glossaryList
                             forgeContext = if (ready.hasForgeContext()) ready.forgeContext else null
                             effectiveLevel = ready.effectiveLevel
-
-                            val ctx = forgeContext
-                            if (ctx == null || ctx.headRef.isEmpty()) {
-                                log.info("Codewalker: no head ref in forge context, skipping working-tree checkout")
-                            } else if (!prepareWorkingTree(ctx.headRef, sessionId ?: ready.sessionId)) {
-                                // Error has already been surfaced; abort the
-                                // upstream stream so this coroutine ends and
-                                // releases the sessionActive gate.
-                                throw SessionPreparationAbort()
-                            }
                             sessionStarted = true
                             withContext(Dispatchers.Main) { panel.showSession() }
                         }
@@ -126,8 +128,6 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                 }
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: SessionPreparationAbort) {
-                // Error was already surfaced inside prepareWorkingTree; nothing else to do.
             } catch (e: Exception) {
                 val formatted = ReviewErrorFormatter.format(e)
                 withContext(Dispatchers.Main) { panel.showError(formatted.message) }
@@ -144,7 +144,7 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
      * On false, the panel has already been navigated back to a non-loading
      * state with an explanation.
      */
-    private suspend fun prepareWorkingTree(headRef: String, sessionTag: String): Boolean {
+    private suspend fun prepareWorkingTree(headRef: String): Boolean {
         val repo = gitOps.firstRepository()
         if (repo == null) {
             log.info("Codewalker: no git repository in project, skipping checkout")
@@ -163,7 +163,8 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                 return false
             }
             try {
-                gitOps.stashChanges(repo, CodewalkerGitOps.stashMessage(sessionTag))
+                val tag = generateStashTag(headRef)
+                gitOps.stashChanges(repo, CodewalkerGitOps.stashMessage(tag))
             } catch (e: GitOperationException) {
                 withContext(Dispatchers.Main) {
                     panel.showError("Couldn't stash changes: ${e.message}. Session not started.")
@@ -188,6 +189,12 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
         }
 
         return true
+    }
+
+    private fun generateStashTag(headRef: String): String {
+        val safeName = headRef.replace(Regex("[^A-Za-z0-9_-]"), "_").take(40)
+        val timestamp = System.currentTimeMillis()
+        return "$safeName-$timestamp"
     }
 
     private fun warnAboutLeftoverStashes() {
@@ -218,6 +225,4 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
         if (host.isEmpty()) return ""
         return TokenStore.getInstance().get(host) ?: ""
     }
-
-    private class SessionPreparationAbort : RuntimeException()
 }


### PR DESCRIPTION
Closes #55.

## Summary

Moves the dirty-tree dialog, stash, fetch, and branch checkout to run **before** `OpenReviewSession` is called, using `PullRequestSummary.head_ref` (added in backend `v0.6.2`).

Previously the working-tree prep ran inside the `REVIEW_READY` handler — by then the backend had already spent ~16s fetching the diff and had built a server-side session that would leak until TTL eviction if the user cancelled at the dirty-tree dialog. With this change, a cancel produces no backend traffic at all.

## Changes

- **`build.gradle.kts`** — bump proto stub to `v0.6.2` to pick up `PullRequestSummary.head_ref`.
- **`ReviewSessionController.kt`**
  - `openReview` now takes a `PullRequestSummary` (rather than just `url`) so the head ref is available before any RPC is made.
  - `prepareWorkingTree` runs first; only on success does the controller open the gRPC stream.
  - The session-ID-based stash tag is replaced with a locally-generated tag (head ref + timestamp) since the session ID does not exist yet at prep time. The `codewalker-` prefix still flows through `CodewalkerGitOps.stashMessage`, so `findCodewalkerStashes` continues to identify these stashes for cleanup.
  - Empty `head_ref` (defensive — older backends, edge cases) skips the checkout cleanly with a log line.
  - Removes the now-unused `SessionPreparationAbort` exception path that existed only to break out of the `collect` lambda after `REVIEW_READY`.
- **`codewalker-intellij-briefing.md`** — document the reordered flow and the new stash-tag generation.

## Test plan

- [ ] `./gradlew check` passes (CI)
- [ ] Click a PR with a clean working tree → checkout happens, then session opens normally
- [ ] Click a PR with a dirty working tree → dialog appears before any gRPC traffic; cancel → no `OpenReviewSession` call (verify in backend logs)
- [ ] Stash and continue → stash created with `codewalker-` prefix, checkout happens, session opens
- [ ] PR with empty `head_ref` (defensive) → session opens without checkout, log line indicates skip
- [ ] Backend not connected → working-tree prep runs first, then connection error from the stub; errors don't conflate

## Sequencing

This depends on backend `v0.6.2` being tagged on JitPack. Once this lands, the previously-filed *"Clean up server-side session when client aborts after ReviewReady"* issue can be closed as obsolete — the failure mode it patched is eliminated by this reordering.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb217DMLZXyQkPASpvugg1)_