### PR TITLE
fix: run warnAboutLeftoverStashes off the EDT

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -55,9 +55,8 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
         panel.idlePanel.clearError()
         panel.showLoading()
 
-        warnAboutLeftoverStashes()
-
         sessionJob = scope.launch {
+            warnAboutLeftoverStashes()
             var sessionStarted = false
             try {
                 // Working-tree prep happens first. If the user cancels or


### PR DESCRIPTION
## Summary

`warnAboutLeftoverStashes()` calls `git stash list` via `GitLineHandler`, which must not run on the EDT. It was being invoked synchronously from `openReview` before the `scope.launch` block, so it ran on the calling thread (typically the EDT, since `openReview` is triggered from a Swing click handler).

Move the call inside the `scope.launch` block so it runs on `Dispatchers.IO` with the rest of the git operations. The warning is informational only, so doing it just before working-tree prep (rather than slightly earlier) makes no user-visible difference.

## Sequencing

This depends on #56 — it's based on that branch since it uses the new `openReview(pr: PullRequestSummary, level: String)` signature. Merge #56 first, or rebase this onto main once #56 lands.

## Test plan

- [ ] `./gradlew check` passes (CI)
- [ ] Open a session with a leftover `codewalker-` stash present → warning still appears in IDE log
- [ ] No "Slow operations are prohibited on EDT" exceptions when starting a session


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb217DMLZXyQkPASpvugg1)_