### PR TITLE
chore: remove unused glossary field

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -2,7 +2,6 @@ package com.snootbeestci.codewalker.session
 
 import codewalker.v1.Codewalker.ExperienceLevel
 import codewalker.v1.Codewalker.ForgeContext
-import codewalker.v1.Codewalker.GlossaryTerm
 import codewalker.v1.Codewalker.PullRequestSummary
 import codewalker.v1.Codewalker.SessionEvent
 import codewalker.v1.Codewalker.Step
@@ -29,7 +28,6 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
     var sessionId: String? = null
     var steps: List<Step> = emptyList()
     var currentStepId: String? = null
-    var glossary: List<GlossaryTerm> = emptyList()
     var forgeContext: ForgeContext? = null
     var effectiveLevel: Int = 6
 
@@ -112,7 +110,6 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
                             sessionId = ready.sessionId
                             steps = ready.stepsList
                             currentStepId = ready.entryStepId
-                            glossary = ready.glossaryList
                             forgeContext = if (ready.hasForgeContext()) ready.forgeContext else null
                             effectiveLevel = ready.effectiveLevel
                             sessionStarted = true


### PR DESCRIPTION
Closes #46.

## Summary

Removes the unused `glossary` field from `ReviewSessionController`. It was written when `ReviewReady` arrived but never read anywhere else in the plugin.

## Changes

`src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt`:

- Removed the `var glossary: List<GlossaryTerm> = emptyList()` field declaration
- Removed the `glossary = ready.glossaryList` assignment in the `REVIEW_READY` event branch
- Dropped the now-unused `import codewalker.v1.Codewalker.GlossaryTerm` (a grep confirmed this was the only reference)

The proto field on `ReviewReady` itself is unaffected — only the unread plugin variable is gone.

## Tests

No test changes; the field had no behaviour to test. A separate follow-up will add `SummaryReady` consumer support once backend `v0.7.0` is on JitPack.

## Verification

- `./gradlew check` could not run in this sandbox — JetBrains hosts (`download.jetbrains.com`, `cache-redirector.jetbrains.com`) return 403 here, so the IntelliJ Platform dependency cannot be resolved. CI will exercise the full check.
- The change is a pure deletion of an unread field, an unread assignment, and one now-orphaned import — no behavioural change.

## Briefing / README

No updates needed. The briefing does not document the glossary field, and developer-facing setup is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XviTTGAk6ayVduepcLeRih)_