### PR TITLE
feat: render summary early via SummaryReady event

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.snootbeestci:codewalker-proto:v0.6.2") {
+    implementation("com.github.snootbeestci:codewalker-proto:v0.7.0") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
     }

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -177,6 +177,22 @@ Colour pairs use `JBColor` so they adapt between light and dark themes.
 - All gRPC calls use Kotlin coroutines — never block the UI thread
 - UI updates always dispatched via `withContext(Dispatchers.Main)`
 
+The navigation stream emits three event variants the plugin handles:
+
+- `token` — narration text. Appended to the narration pane as it
+  arrives.
+- `summary_ready` — structured summary (risk, breaking, tests, etc.).
+  Updates the summary table immediately, typically before narration
+  finishes streaming. New as of backend v0.7.0.
+- `complete` — terminal event. Updates breadcrumb, navigation buttons,
+  step highlight, and (for backward compatibility) the summary table
+  again. Clients running against pre-v0.7.0 backends rely on this for
+  the summary, so the redundant update is intentional.
+
+The summary table thus populates ~6 seconds earlier than narration
+finishes, giving the reviewer risk/breaking/tests at-a-glance before
+reading the full prose.
+
 ---
 
 ## Token resolution order

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/NavigationController.kt
@@ -83,6 +83,9 @@ class NavigationController(
                         event.hasToken() -> withContext(Dispatchers.Main) {
                             panel.appendNarrationToken(event.token.text)
                         }
+                        event.hasSummaryReady() -> withContext(Dispatchers.Main) {
+                            panel.onSummaryReady(event.summaryReady.summary)
+                        }
                         event.hasComplete() -> withContext(Dispatchers.Main) {
                             panel.onStepComplete(event.complete)
                         }

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -4,6 +4,7 @@ import codewalker.v1.Codewalker.EdgeLabel
 import codewalker.v1.Codewalker.ReviewFile
 import codewalker.v1.Codewalker.Step
 import codewalker.v1.Codewalker.StepComplete
+import codewalker.v1.Codewalker.StepSummary
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -265,6 +266,10 @@ class SessionPanel(
         val doc = narrationPane.document
         doc.insertString(doc.length, text, null)
         narrationPane.caretPosition = doc.length
+    }
+
+    fun onSummaryReady(summary: StepSummary) {
+        summaryTable.update(summary)
     }
 
     fun onStepComplete(complete: StepComplete) {


### PR DESCRIPTION
Closes #59

## Summary

Backend `v0.7.0` emits a `NarrateEvent.summary_ready` variant as soon as the structured step summary is available — typically 6–7 seconds before narration finishes streaming. The plugin now consumes it so the summary table populates immediately rather than waiting for `Complete`.

## Changes

- **`build.gradle.kts`** — bumped proto stub from `v0.6.2` to `v0.7.0`.
- **`NavigationController.kt`** — added a `hasSummaryReady()` branch in the navigate event collector that calls `panel.onSummaryReady(event.summaryReady.summary)`.
- **`SessionPanel.kt`** — added `onSummaryReady(summary: StepSummary)` that delegates to `summaryTable.update(summary)`. `onStepComplete` keeps its existing summary update for backward compatibility with pre-v0.7.0 backends; `summaryTable.update` is idempotent.
- **`codewalker-intellij-briefing.md`** — documented the three navigation event variants (`token`, `summary_ready`, `complete`) and the deliberate redundant summary update on `complete`.

## Test plan

- [ ] `./gradlew check` passes (sandbox cannot reach JetBrains Maven repos in this environment, so this needs a manual run)
- [ ] Click a PR step → narration tokens stream, summary table is empty
- [ ] Within ~2 seconds, summary table populates with risk/breaking/tests
- [ ] Narration finishes some seconds later → breadcrumb updates, nav buttons enable; summary unchanged
- [ ] Run against a pre-v0.7.0 backend → summary still appears via the `Complete.summary` fallback path

https://claude.ai/code/session_01LUs6Loa3HUEn98YCa2K9Sr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUs6Loa3HUEn98YCa2K9Sr)_