### PR TITLE
feat: loading indicator while summary is being generated

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -126,8 +126,28 @@ Inside the SESSION card, the body is a horizontal `JBSplitter`:
 
 `SessionPanel.onStepComplete` calls `summaryTable.update(complete.summary)`
 when `complete.hasSummary()` is true, otherwise passes `null` (which clears
-the table). `SessionPanel.clearNarration` clears both the narration pane
-and the summary table.
+the table). `SessionPanel.clearNarration` clears the narration pane and
+puts the summary table into its loading state (see below).
+
+The summary table has two display states:
+
+- **Loading** — a spinner with "Generating summary…" label, shown while
+  the backend is generating the structured summary. Entered via
+  `summaryTable.showLoading()`, which `SessionPanel.clearNarration()`
+  calls at the start of every navigation.
+- **Populated** — the eight-row table with risk/breaking/tests etc.,
+  shown once `SummaryReady` (or `Complete` for older backends) provides
+  the summary. Entered via `summaryTable.update(summary)`.
+
+The loading state typically lasts 2–4 seconds. Without it, the user
+sees `—` placeholders that read as "no data" rather than "loading",
+making the panel feel unresponsive even when work is in progress.
+
+`summaryTable.clear()` resets to empty placeholders without entering
+the loading state — used for navigation cleanup and dispose. The
+spinner is an `AsyncProcessIcon` whose animation lifecycle is driven
+by component visibility via `CardLayout`, so no manual start/stop is
+required.
 
 The file/step list is built by joining `ReviewReady.forge_context.files`
 (canonical file order, deterministic, aligned with backend Forward

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -259,7 +259,7 @@ class SessionPanel(
 
     fun clearNarration() {
         narrationPane.text = ""
-        summaryTable.clear()
+        summaryTable.showLoading()
     }
 
     fun appendNarrationToken(text: String) {

--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTable.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SummaryTable.kt
@@ -3,14 +3,18 @@ package com.snootbeestci.codewalker.toolwindow
 import codewalker.v1.Codewalker.StepSummary
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.AsyncProcessIcon
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.CardLayout
 import java.awt.Color
 import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.Insets
+import javax.swing.Box
+import javax.swing.BoxLayout
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JTextArea
@@ -18,7 +22,6 @@ import javax.swing.UIManager
 
 class SummaryTable {
 
-    val root: JPanel = JPanel(BorderLayout())
     private val rowsPanel: JPanel = JPanel(GridBagLayout())
 
     private val pillLabel: JBLabel = JBLabel("").apply {
@@ -39,12 +42,36 @@ class SummaryTable {
         "Confidence" to makeValueCell(),
     )
 
+    private val tableCard: JPanel = JPanel(BorderLayout())
+
+    private val loadingCard: JPanel = JPanel(GridBagLayout()).apply {
+        val container = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.X_AXIS)
+            isOpaque = false
+            add(AsyncProcessIcon("CodewalkerSummaryLoading"))
+            add(Box.createHorizontalStrut(8))
+            add(JBLabel("Generating summary…").apply {
+                foreground = UIManager.getColor("Label.disabledForeground")
+                    ?: JBColor.GRAY
+            })
+        }
+        add(container, GridBagConstraints())
+        border = JBUI.Borders.empty(24, 0)
+    }
+
+    private val cardLayout: CardLayout = CardLayout()
+
+    val root: JPanel = JPanel(cardLayout).apply {
+        add(tableCard, CARD_TABLE)
+        add(loadingCard, CARD_LOADING)
+    }
+
     init {
         val pillWrapper = JPanel(FlowLayout(FlowLayout.LEFT, 8, 4)).apply {
             add(pillLabel)
         }
-        root.add(pillWrapper, BorderLayout.NORTH)
-        root.add(rowsPanel, BorderLayout.CENTER)
+        tableCard.add(pillWrapper, BorderLayout.NORTH)
+        tableCard.add(rowsPanel, BorderLayout.CENTER)
 
         rows.forEachIndexed { index, (label, valueCell) ->
             valueCell.text = EMPTY_VALUE
@@ -68,9 +95,14 @@ class SummaryTable {
         }
     }
 
+    fun showLoading() {
+        cardLayout.show(root, CARD_LOADING)
+    }
+
     fun update(summary: StepSummary?) {
         if (summary == null) {
-            clear()
+            resetRows()
+            cardLayout.show(root, CARD_TABLE)
             return
         }
         val breakingSeverity = SeverityParser.forBreaking(summary.breaking)
@@ -87,17 +119,23 @@ class SummaryTable {
         setCell(7, summary.confidence, Severity.NEUTRAL)
 
         updatePill(SeverityParser.worst(breakingSeverity, riskSeverity, testsSeverity))
+        cardLayout.show(root, CARD_TABLE)
     }
 
     fun clear() {
+        resetRows()
+        cardLayout.show(root, CARD_TABLE)
+    }
+
+    fun valueLabelAt(index: Int): JTextArea = rows[index].second
+
+    private fun resetRows() {
         rows.forEach { (_, cell) ->
             cell.text = EMPTY_VALUE
             applyForeground(cell, Severity.NEUTRAL)
         }
         updatePill(Severity.NEUTRAL)
     }
-
-    fun valueLabelAt(index: Int): JTextArea = rows[index].second
 
     private fun setCell(index: Int, value: String, severity: Severity) {
         val cell = rows[index].second
@@ -146,6 +184,9 @@ class SummaryTable {
 
     companion object {
         const val EMPTY_VALUE: String = "—"
+
+        private const val CARD_TABLE = "table"
+        private const val CARD_LOADING = "loading"
 
         private val GREEN_FG = JBColor(Color(0x2E7D32), Color(0x81C784))
         private val AMBER_FG = JBColor(Color(0xE65100), Color(0xFFB74D))


### PR DESCRIPTION
## Summary

Replaces the `—` placeholders that appear in the summary table during the 2–4 seconds the backend takes to generate the structured summary. The table now shows an `AsyncProcessIcon` spinner with a "Generating summary…" label so the panel reads as "loading" rather than "no data".

Closes #45.

## Changes

- `SummaryTable.kt` — wrap the existing rows panel and the new loading panel in a `CardLayout` (`tableCard` / `loadingCard`). Add `showLoading()` to swap to the loading card. `update(summary)` and `clear()` both swap back to the populated card. The spinner uses IntelliJ's `AsyncProcessIcon`, and the label uses `Label.disabledForeground` (with `JBColor.GRAY` fallback) so it renders cleanly in both Light and Darcula. `clear()` keeps its "reset to empty placeholders" semantics — only `showLoading()` enters the loading state, so the panel never spins when no work is in flight.
- `SessionPanel.kt` — `clearNarration()` now calls `summaryTable.showLoading()` instead of `summaryTable.clear()`. `clearNarration()` is invoked at the start of every navigation, immediately followed by the gRPC stream, so the loading state matches the actual flow. `onSummaryReady` and `onStepComplete` already call `summaryTable.update(...)`, which transitions back to the populated card automatically.
- `codewalker-intellij-briefing.md` — document the two display states (Loading / Populated), how each is entered, and the `clear()` vs `showLoading()` distinction.

Note on imports: the issue spec referenced `com.intellij.openapi.ui.AsyncProcessIcon`, but the class actually lives in `com.intellij.util.ui.AsyncProcessIcon` — used that path.

## Test plan

No new unit tests — this is visual state with no parseable behaviour.

- [ ] `./gradlew check` passes (blocked locally in this sandbox: the JetBrains Maven repos required to resolve `ideaIC:2025.1` are not reachable, so `check` could not be run here. CI will run it on the PR.)
- [ ] Click a PR step → summary table replaces with spinner + "Generating summary…"
- [ ] After 2–4 seconds, spinner disappears and the table populates
- [ ] Click another step → spinner returns immediately, then populates
- [ ] Walkthrough step (no summary) → after stream completes, table shows `—` placeholders (no lingering spinner)
- [ ] Theme switch (Light → Darcula) → spinner and label readable in both


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLHggQezJgfv7YVQR2A67f)_