### PR TITLE
fix: update step list highlight on pre-fetch navigation

### DIFF
--- a/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/toolwindow/SessionPanel.kt
@@ -147,6 +147,7 @@ class SessionPanel(
 
     private var controller: ReviewSessionController? = null
     private var navigationController: NavigationController? = null
+    private var suppressSelectionListener = false
 
     init {
         buildLayout()
@@ -224,6 +225,7 @@ class SessionPanel(
         forwardButton.addActionListener { navigationController?.navigateForward() }
         stepList.addListSelectionListener { event ->
             if (event.valueIsAdjusting) return@addListSelectionListener
+            if (suppressSelectionListener) return@addListSelectionListener
             val item = stepList.selectedValue ?: return@addListSelectionListener
             if (item is StepListItem.Header || item is StepListItem.Subtitle) {
                 stepList.clearSelection()
@@ -285,6 +287,7 @@ class SessionPanel(
     }
 
     fun applyHighlightFor(step: Step) {
+        updateStepHighlight(step.id)
         if (step.hasHunkSpan()) {
             highlighter.highlightHunk(step.hunkSpan)
         }
@@ -299,11 +302,16 @@ class SessionPanel(
             val item = stepListModel.getElementAt(it)
             item is StepListItem.StepRow && item.stepId == stepId
         }
-        if (idx != null) {
-            stepList.selectedIndex = idx
-            stepList.ensureIndexIsVisible(idx)
-        } else {
-            stepList.clearSelection()
+        suppressSelectionListener = true
+        try {
+            if (idx != null) {
+                stepList.selectedIndex = idx
+                stepList.ensureIndexIsVisible(idx)
+            } else {
+                stepList.clearSelection()
+            }
+        } finally {
+            suppressSelectionListener = false
         }
     }
 


### PR DESCRIPTION
## Summary

`SessionPanel.applyHighlightFor` was only highlighting the editor hunk; the step-list selection waited until `onStepComplete` fired after the gRPC round-trip, so the list lagged the editor by the full streaming duration. The briefing already describes this entry point as the "pre-fetch highlight" that should land on the right file before the RPC returns — the list highlight just wasn't part of it.

This change makes `applyHighlightFor` call `updateStepHighlight(step.id)` up front so both surfaces move together when the user clicks Forward/Back, matches a step row, or resumes a session via `bind`.

The mechanical wrinkle: programmatically setting `stepList.selectedIndex` re-enters the selection listener attached in `wireListeners`, which would interpret the move as a user click and call `navigationController.navigateTo(...)` — cancelling the in-flight Forward/Back RPC and replacing it with a stepId RPC. A `suppressSelectionListener` flag is toggled around every programmatic mutation in `updateStepHighlight` so re-entry is ignored. User clicks remain unaffected because they go through the listener with the flag clear.

## Test plan

- [ ] Click Forward and observe the step list selection and the editor highlight move together, before narration begins streaming
- [ ] Click Back; same behaviour in reverse
- [ ] Click a step row directly; navigation still fires (listener path unaffected by the flag)
- [ ] Resume a session via `bind`; current step is highlighted in both list and editor immediately
- [ ] `./gradlew check` passes (could not be run locally — JetBrains repository unreachable in sandbox; CI to verify)

> Note: `./gradlew check` could not be executed in the sandbox where this PR was prepared because the IntelliJ Platform artifacts (`idea:ideaIC:2025.1`) are fetched from `download.jetbrains.com` / `cache-redirector.jetbrains.com` and both return 403 from this network. The change is a small, self-contained edit to one file; CI should validate cleanly.

https://claude.ai/code/session_01M3fFJUqzo84gRr7AJBhyFL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3fFJUqzo84gRr7AJBhyFL)_