### PR TITLE
feat(editor): show diff hunk in popup on click over highlighted code

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -378,6 +378,17 @@ construction. The highlighter retains the fetch-and-compare logic as a
 safety net for projects without a git repository or when checkout was
 skipped.
 
+Highlighted regions in the editor are clickable. A left click on a
+highlighted line opens a popup showing the unified diff for that hunk,
+including removed lines that are not visible in the head-ref content
+displayed in the editor. Clicking the same region again dismisses the
+popup; clicking outside the highlight or outside the editor dismisses
+it as well. Modified clicks (ctrl, shift, alt, meta) fall through to
+the IDE's default handlers so existing gestures like Find Usages
+continue to work.
+
+The popup is non-focusable so the editor retains keyboard focus.
+
 ---
 
 ## Future direction

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -8,6 +8,9 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseEventArea
+import com.intellij.openapi.editor.event.EditorMouseListener
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.intellij.openapi.editor.markup.RangeHighlighter
@@ -16,12 +19,15 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBScrollPane
 import com.snootbeestci.codewalker.forge.HostNormalizer
 import com.snootbeestci.codewalker.forge.TokenStore
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
@@ -36,6 +42,11 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.awt.Color
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Point
+import java.awt.event.MouseEvent
+import javax.swing.JTextArea
 
 class EditorHighlighter(
     private val project: Project,
@@ -46,6 +57,9 @@ class EditorHighlighter(
 
     private var currentHighlighters: List<RangeHighlighter> = emptyList()
     private var currentEditor: Editor? = null
+    private var clickListener: EditorMouseListener? = null
+    private var activePopup: JBPopup? = null
+    private var currentRawDiff: String = ""
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val contentCache = mutableMapOf<Pair<String, String>, ByteArray>()
@@ -157,6 +171,7 @@ class EditorHighlighter(
     private fun applyHighlightRanges(editor: Editor, span: HunkSpan) {
         val document = editor.document
         val ranges = computeAddedLineRanges(span.rawDiff, span.newStart)
+        currentRawDiff = span.rawDiff
 
         val attributes = TextAttributes().apply {
             backgroundColor = JBColor(
@@ -188,12 +203,87 @@ class EditorHighlighter(
             LogicalPosition(scrollLine, 0),
             ScrollType.CENTER
         )
+
+        attachClickListener(editor)
+    }
+
+    private fun attachClickListener(editor: Editor) {
+        val listener = object : EditorMouseListener {
+            override fun mouseClicked(e: EditorMouseEvent) {
+                val mouseEvent = e.mouseEvent
+                if (mouseEvent.button != MouseEvent.BUTTON1) return
+                if (mouseEvent.modifiersEx and (
+                    MouseEvent.SHIFT_DOWN_MASK or
+                        MouseEvent.CTRL_DOWN_MASK or
+                        MouseEvent.ALT_DOWN_MASK or
+                        MouseEvent.META_DOWN_MASK
+                    ) != 0) return
+                if (e.area != EditorMouseEventArea.EDITING_AREA) return
+
+                val clickedLine = editor.xyToLogicalPosition(mouseEvent.point).line
+                if (!isLineHighlighted(clickedLine)) {
+                    activePopup?.cancel()
+                    activePopup = null
+                    return
+                }
+
+                if (activePopup?.isVisible == true) {
+                    activePopup?.cancel()
+                    activePopup = null
+                    return
+                }
+
+                showDiffPopup(editor, mouseEvent.locationOnScreen)
+            }
+        }
+        editor.addEditorMouseListener(listener)
+        clickListener = listener
+    }
+
+    private fun isLineHighlighted(line: Int): Boolean {
+        val editor = currentEditor ?: return false
+        return currentHighlighters.any { highlighter ->
+            val startLine = editor.document.getLineNumber(highlighter.startOffset)
+            val endLine = editor.document.getLineNumber(highlighter.endOffset)
+            line in startLine..endLine
+        }
+    }
+
+    private fun showDiffPopup(editor: Editor, screenLocation: Point) {
+        if (currentRawDiff.isEmpty()) return
+
+        val textArea = JTextArea(currentRawDiff).apply {
+            font = Font(Font.MONOSPACED, Font.PLAIN, 12)
+            isEditable = false
+            lineWrap = false
+        }
+        val scrollPane = JBScrollPane(textArea).apply {
+            preferredSize = Dimension(600, 300)
+        }
+
+        val popup = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(scrollPane, textArea)
+            .setRequestFocus(false)
+            .setFocusable(false)
+            .setMovable(true)
+            .setResizable(true)
+            .setCancelOnClickOutside(true)
+            .setCancelOnOtherWindowOpen(true)
+            .createPopup()
+
+        popup.showInScreenCoordinates(editor.component, screenLocation)
+        activePopup = popup
     }
 
     fun clearHighlight() {
+        activePopup?.cancel()
+        activePopup = null
+        clickListener?.let { l -> currentEditor?.removeEditorMouseListener(l) }
+        clickListener = null
         currentHighlighters.forEach { it.dispose() }
         currentHighlighters = emptyList()
         currentEditor = null
+        currentRawDiff = ""
     }
 
     private fun findWorkingTreeFile(filePath: String): VirtualFile? {


### PR DESCRIPTION
Closes #23.

## Summary

Left-clicking a highlighted region in the editor now opens a popup
containing the full unified diff for that hunk — including removed
lines that aren't visible in the head-ref content displayed in the
editor.

- New click listener attached in `EditorHighlighter.applyHighlightRanges`,
  removed in `clearHighlight`. The listener captures `span.rawDiff` via
  `currentRawDiff` so the popup has a single source of truth.
- Toggle semantics: clicking a highlighted line with the popup open
  dismisses it. Clicking on a non-highlighted line or outside the editor
  also dismisses (`setCancelOnClickOutside(true)` plus an explicit cancel
  for the in-editor case).
- Modifier-key clicks (ctrl, shift, alt, meta) fall through unmodified so
  Find Usages, multi-cursor, etc. continue to work.
- Popup is non-focusable (`setRequestFocus(false)`, `setFocusable(false)`)
  so editor keyboard focus is preserved. It is monospaced, scrollable,
  resizable, and movable.
- Listener and popup are torn down in `clearHighlight`, which is called
  on every navigation and via `dispose`, so there are no cross-session
  leaks.

## Files

- `src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt`
  — fields, click listener, popup builder, lifecycle.
- `codewalker-intellij-briefing.md` — appends the popup contract to the
  Review session file display section.

## Build status

`./gradlew check` could not be executed in this sandbox: the IntelliJ
platform artifact (`idea:ideaIC:2025.1`) returns HTTP 403 from
`download.jetbrains.com`, `cache-redirector.jetbrains.com`, and
`jitpack.io` in the build environment. Please run `./gradlew check`
locally before merging.

## Test plan

No unit tests — IntelliJ editor mouse interaction isn't unit-testable
in isolation. Manual verification per the issue's acceptance criteria:

- [ ] Open a session, navigate to a step. Editor shows head-ref content
      with a highlight.
- [ ] Click on a highlighted line → popup appears at click location with
      `+`, `-`, ` `, `@@` lines.
- [ ] Click the same highlighted region again → popup dismisses.
- [ ] Click on a different highlighted line → popup re-opens at the new
      location.
- [ ] Click on a non-highlighted line → popup dismisses, no new popup
      opens.
- [ ] Click outside the editor → popup dismisses.
- [ ] Long-diff hunk → popup is scrollable.
- [ ] Ctrl-click on a highlighted line → does NOT trigger popup; IDE
      handles the click as Find Usages or similar.
- [ ] Navigate to next step → popup dismisses cleanly, listener attached
      to new highlight.
- [ ] `./gradlew check` passes locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljox4BVvcnTfVsMpfZj2A1)_