### PR TITLE
feat(editor): syntax highlighting and line numbers in diff popup

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -387,6 +387,14 @@ it as well. Modified clicks (ctrl, shift, alt, meta) fall through to
 the IDE's default handlers so existing gestures like Find Usages
 continue to work.
 
+While the mouse is over a highlighted line the editor cursor switches
+from the I-beam to the default arrow as a hover affordance. This is
+done via `EditorEx.setCustomCursor(this, …)`, which scopes the
+override to the highlighter so other editor cursor logic (e.g.
+hyperlinks elsewhere) is not affected. Passing `null` as the cursor
+clears the override; this happens when the mouse leaves a highlight
+and on `clearHighlight()`.
+
 The diff popup uses an IntelliJ editor viewer configured with the Diff
 file type, giving syntax-coloured +/-/@@ lines, line numbers in the
 gutter, find-in-popup (cmd/ctrl-F), and copy-with-formatting. The

--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -387,7 +387,12 @@ it as well. Modified clicks (ctrl, shift, alt, meta) fall through to
 the IDE's default handlers so existing gestures like Find Usages
 continue to work.
 
-The popup is non-focusable so the editor retains keyboard focus.
+The diff popup uses an IntelliJ editor viewer configured with the Diff
+file type, giving syntax-coloured +/-/@@ lines, line numbers in the
+gutter, find-in-popup (cmd/ctrl-F), and copy-with-formatting. The
+viewer is read-only and non-focusable, so the underlying editor keeps
+keyboard focus. The viewer is disposed when the popup closes, via
+Disposer.register on the popup itself.
 
 ---
 

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -6,11 +6,14 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseEventArea
 import com.intellij.openapi.editor.event.EditorMouseListener
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.highlighter.EditorHighlighterFactory
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.intellij.openapi.editor.markup.RangeHighlighter
@@ -21,13 +24,13 @@ import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.ui.JBColor
-import com.intellij.ui.components.JBScrollPane
 import com.snootbeestci.codewalker.forge.HostNormalizer
 import com.snootbeestci.codewalker.forge.TokenStore
 import com.snootbeestci.codewalker.grpc.CodewalkerClient
@@ -43,10 +46,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.awt.Color
 import java.awt.Dimension
-import java.awt.Font
 import java.awt.Point
 import java.awt.event.MouseEvent
-import javax.swing.JTextArea
 
 class EditorHighlighter(
     private val project: Project,
@@ -252,17 +253,30 @@ class EditorHighlighter(
     private fun showDiffPopup(editor: Editor, screenLocation: Point) {
         if (currentRawDiff.isEmpty()) return
 
-        val textArea = JTextArea(currentRawDiff).apply {
-            font = Font(Font.MONOSPACED, Font.PLAIN, 12)
-            isEditable = false
-            lineWrap = false
-        }
-        val scrollPane = JBScrollPane(textArea).apply {
-            preferredSize = Dimension(600, 300)
+        val editorFactory = EditorFactory.getInstance()
+        val document = editorFactory.createDocument(currentRawDiff)
+        val viewer = editorFactory.createViewer(document, project) as EditorEx
+
+        val diffFileType = FileTypeManager.getInstance().findFileTypeByName("Diff")
+        if (diffFileType != null) {
+            viewer.highlighter = EditorHighlighterFactory.getInstance()
+                .createEditorHighlighter(project, diffFileType)
         }
 
+        viewer.settings.apply {
+            isLineNumbersShown = true
+            isLineMarkerAreaShown = false
+            isFoldingOutlineShown = false
+            isRightMarginShown = false
+            additionalLinesCount = 0
+            additionalColumnsCount = 0
+            isCaretRowShown = false
+        }
+        viewer.isViewer = true
+        viewer.component.preferredSize = Dimension(700, 350)
+
         val popup = JBPopupFactory.getInstance()
-            .createComponentPopupBuilder(scrollPane, textArea)
+            .createComponentPopupBuilder(viewer.component, viewer.contentComponent)
             .setRequestFocus(false)
             .setFocusable(false)
             .setMovable(true)
@@ -270,6 +284,10 @@ class EditorHighlighter(
             .setCancelOnClickOutside(true)
             .setCancelOnOtherWindowOpen(true)
             .createPopup()
+
+        Disposer.register(popup) {
+            editorFactory.releaseEditor(viewer)
+        }
 
         popup.showInScreenCoordinates(editor.component, screenLocation)
         activePopup = popup

--- a/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseEventArea
 import com.intellij.openapi.editor.event.EditorMouseListener
+import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.highlighter.EditorHighlighterFactory
 import com.intellij.openapi.editor.markup.HighlighterLayer
@@ -45,6 +46,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.awt.Color
+import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Point
 import java.awt.event.MouseEvent
@@ -59,6 +61,7 @@ class EditorHighlighter(
     private var currentHighlighters: List<RangeHighlighter> = emptyList()
     private var currentEditor: Editor? = null
     private var clickListener: EditorMouseListener? = null
+    private var motionListener: EditorMouseMotionListener? = null
     private var activePopup: JBPopup? = null
     private var currentRawDiff: String = ""
 
@@ -206,6 +209,23 @@ class EditorHighlighter(
         )
 
         attachClickListener(editor)
+        attachCursorListener(editor)
+    }
+
+    private fun attachCursorListener(editor: Editor) {
+        if (editor !is EditorEx) return
+        val listener = object : EditorMouseMotionListener {
+            override fun mouseMoved(e: EditorMouseEvent) {
+                val overHighlight = e.area == EditorMouseEventArea.EDITING_AREA &&
+                    isLineHighlighted(editor.xyToLogicalPosition(e.mouseEvent.point).line)
+                editor.setCustomCursor(
+                    this@EditorHighlighter,
+                    if (overHighlight) Cursor.getDefaultCursor() else null,
+                )
+            }
+        }
+        editor.addEditorMouseMotionListener(listener)
+        motionListener = listener
     }
 
     private fun attachClickListener(editor: Editor) {
@@ -298,6 +318,9 @@ class EditorHighlighter(
         activePopup = null
         clickListener?.let { l -> currentEditor?.removeEditorMouseListener(l) }
         clickListener = null
+        motionListener?.let { l -> currentEditor?.removeEditorMouseMotionListener(l) }
+        motionListener = null
+        (currentEditor as? EditorEx)?.setCustomCursor(this, null)
         currentHighlighters.forEach { it.dispose() }
         currentHighlighters = emptyList()
         currentEditor = null


### PR DESCRIPTION
Closes #64.

## Summary

Two related editor-affordance changes for highlighted hunks:

### 1. Syntax-highlighted diff popup (issue #64)

Replaces the plain `JTextArea` in the diff popup with a real IntelliJ `Editor` viewer configured with the Diff file type. The reviewer now gets:

- Unified-diff syntax highlighting (`+` green, `-` red, `@@` headers) that follows the active colour scheme
- Line numbers in the gutter
- Find-in-popup (cmd/ctrl-F)
- Theme integration for free (Darcula vs. Light)
- Copy-with-formatting that pastes the diff text faithfully

The viewer is created via `EditorFactory.createViewer`, with line markers / folding / right margin / caret row turned off so only line numbers are visible. The popup remains non-focusable, so the underlying editor keeps keyboard focus.

The viewer is disposed via `Disposer.register(popup) { editorFactory.releaseEditor(viewer) }` — fires whether the popup closes by click-outside, Escape, or via `clearHighlight()` cancelling it on next navigation. No leaked documents, listeners, or gutter components across repeated open/close cycles.

Popup dimensions bumped from 600×300 to 700×350 to compensate for the gutter (~40px) and viewer padding so the visible diff area stays roughly the same.

### 2. Hover affordance via cursor change

While the mouse is over a highlighted line the editor cursor switches from the I-beam to the default arrow, signalling the region is interactive. Implemented as an `EditorMouseMotionListener` that calls `EditorEx.setCustomCursor(this, …)` — scoped to the highlighter, so other editor cursor logic (hyperlinks etc.) is not affected. The override is cleared (passing `null`) when the mouse leaves the highlight or on `clearHighlight()`.

## Files changed

- `src/main/kotlin/com/snootbeestci/codewalker/editor/EditorHighlighter.kt`
  - `showDiffPopup` rewritten to use `EditorFactory.createViewer` + Diff file type
  - New `attachCursorListener` + `motionListener` lifecycle, cleaned up in `clearHighlight`
  - Imports updated (added `EditorFactory`, `EditorEx`, `EditorHighlighterFactory`, `Disposer`, `EditorMouseMotionListener`, `Cursor`; removed `JBScrollPane`, `JTextArea`, `java.awt.Font`)
- `codewalker-intellij-briefing.md` — popup section now documents the editor-viewer behaviour and the cursor hover affordance

## Commits

1. `feat(editor): syntax highlighting and line numbers in diff popup`
2. `feat(editor): switch cursor to arrow over highlighted hunks`

## Test plan

Diff popup:
- [ ] Click a highlighted region → popup opens with syntax-coloured diff (`+` green, `-` red, `@@` header coloured)
- [ ] Line numbers visible in the gutter
- [ ] Cmd/ctrl-F inside the popup opens find toolbar
- [ ] Select-and-copy from the popup pastes diff text without gutter/line-number noise
- [ ] Toggle IDE theme between Light and Darcula → popup colours update on next open
- [ ] Open/close popup repeatedly → no memory growth
- [ ] Navigate to a different step while popup is open → popup dismisses, no leftover editor
- [ ] Long diff → scrollbar appears, scrolling smooth
- [ ] Modified clicks (ctrl/shift/alt/meta) still fall through to the IDE
- [ ] Underlying editor retains keyboard focus while popup is open

Cursor:
- [ ] Mouse over a highlighted line → cursor changes from I-beam to arrow
- [ ] Mouse leaves the highlight → cursor returns to I-beam
- [ ] Navigate to a new step → cursor override cleared on the previous editor

## Notes

`./gradlew check` could not be run in this sandbox — the JetBrains download host is blocked (403 `host_not_allowed`), so the IntelliJ Platform dependency cannot resolve. CI will validate.