### PR TITLE
fix: prefer project-root repository over submodules (#69)

### DIFF
--- a/codewalker-intellij-briefing.md
+++ b/codewalker-intellij-briefing.md
@@ -379,6 +379,22 @@ function resumes when the AWT-later callback fires), and
 `GitOperationException`, which the controller surfaces verbatim to
 the user.
 
+Projects can contain multiple git repositories — typically the
+project root plus one or more submodules. The plugin treats the
+project root's repository as the primary one for "what PRs am I
+reviewing" and for session-time checkout/stash work. The primary
+repository is the one whose root path matches the IDE project's
+`basePath`; if no repository matches (e.g. the project is opened
+inside a sub-directory of a repo), the plugin falls back to the
+first repository the manager returns. Submodule repositories are
+otherwise ignored. The selection lives in
+`CodewalkerGitOps.pickPrimaryRepository` and is used by both
+`CodewalkerGitOps.primaryRepository` and `GitHubRemoteResolver` so
+both code paths agree on which repo represents the project.
+
+Multi-repo projects where the user wants to review PRs in a
+submodule are not supported in this version.
+
 The legacy `EditorHighlighter` `FetchFileAtRef`-based fallback (head-ref
 content fetched over gRPC and rendered in a `LightVirtualFile` when the
 working tree was out of sync) is no longer the primary path — once the

--- a/src/main/kotlin/com/snootbeestci/codewalker/git/CodewalkerGitOps.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/git/CodewalkerGitOps.kt
@@ -25,8 +25,7 @@ class CodewalkerGitOps(private val project: Project) {
 
     private val log = Logger.getInstance(CodewalkerGitOps::class.java)
 
-    fun firstRepository(): GitRepository? =
-        GitRepositoryManager.getInstance(project).repositories.firstOrNull()
+    fun primaryRepository(): GitRepository? = pickPrimaryRepository(project)
 
     fun isWorkingTreeDirty(repo: GitRepository): Boolean {
         val tracked = ChangeListManager.getInstance(project).allChanges
@@ -98,6 +97,20 @@ class CodewalkerGitOps(private val project: Project) {
         const val CODEWALKER_STASH_TAG = "codewalker-"
 
         fun stashMessage(sessionTag: String): String = "$CODEWALKER_STASH_TAG$sessionTag"
+
+        /**
+         * Picks the project's primary git repository. Projects can contain
+         * multiple repositories (typically the project root plus one or more
+         * submodules). The primary one is the repository whose root matches
+         * the project's `basePath`. Falls back to the first-found repository
+         * when no root matches (e.g. project not opened at the repo root).
+         */
+        fun pickPrimaryRepository(project: Project): GitRepository? {
+            val manager = GitRepositoryManager.getInstance(project)
+            val basePath = project.basePath ?: return manager.repositories.firstOrNull()
+            return manager.repositories.firstOrNull { it.root.path == basePath }
+                ?: manager.repositories.firstOrNull()
+        }
 
         /**
          * Pure helper extracted from [findCodewalkerStashes] for unit testing.

--- a/src/main/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/git/GitHubRemoteResolver.kt
@@ -2,7 +2,6 @@ package com.snootbeestci.codewalker.git
 
 import com.intellij.openapi.project.Project
 import com.snootbeestci.codewalker.forge.HostNormalizer
-import git4idea.repo.GitRepositoryManager
 
 data class ProjectRepoInfo(
     val host: String,
@@ -24,10 +23,8 @@ sealed class RemoteParseResult {
 object GitHubRemoteResolver {
 
     fun resolve(project: Project): ProjectRepoInfo? {
-        val repos = GitRepositoryManager.getInstance(project).repositories
-        val origin = repos.firstNotNullOfOrNull { repo ->
-            repo.remotes.firstOrNull { it.name == "origin" }
-        } ?: return null
+        val repo = CodewalkerGitOps.pickPrimaryRepository(project) ?: return null
+        val origin = repo.remotes.firstOrNull { it.name == "origin" } ?: return null
 
         val url = origin.firstUrl ?: return null
         return parseRemoteUrl(url)
@@ -39,10 +36,8 @@ object GitHubRemoteResolver {
      * different error messages.
      */
     fun resolveResult(project: Project): RemoteParseResult {
-        val repos = GitRepositoryManager.getInstance(project).repositories
-        val origin = repos.firstNotNullOfOrNull { repo ->
-            repo.remotes.firstOrNull { it.name == "origin" }
-        } ?: return RemoteParseResult.Empty
+        val repo = CodewalkerGitOps.pickPrimaryRepository(project) ?: return RemoteParseResult.Empty
+        val origin = repo.remotes.firstOrNull { it.name == "origin" } ?: return RemoteParseResult.Empty
 
         val url = origin.firstUrl ?: return RemoteParseResult.Empty
         return parseRemoteUrlResult(url)

--- a/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
+++ b/src/main/kotlin/com/snootbeestci/codewalker/session/ReviewSessionController.kt
@@ -141,7 +141,7 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
      * state with an explanation.
      */
     private suspend fun prepareWorkingTree(headRef: String): Boolean {
-        val repo = gitOps.firstRepository()
+        val repo = gitOps.primaryRepository()
         if (repo == null) {
             log.info("Codewalker: no git repository in project, skipping checkout")
             return true
@@ -194,7 +194,7 @@ class ReviewSessionController(private val panel: CodewalkerPanel) {
     }
 
     private fun warnAboutLeftoverStashes() {
-        val repo = gitOps.firstRepository() ?: return
+        val repo = gitOps.primaryRepository() ?: return
         val leftover = gitOps.findCodewalkerStashes(repo)
         if (leftover.isNotEmpty()) {
             log.warn(


### PR DESCRIPTION
Fixes #69.

## Summary

In multi-repo projects (project root + git submodules), the plugin was picking whichever repository `GitRepositoryManager` returned first. That could be a submodule, producing the wrong `owner/repo` in `IdlePanel`'s "Reviewing PRs for ..." header and meaning session-time checkout/stash ran against the wrong repo.

The fix prefers the repository whose root matches the project's `basePath`, falling back to first-found when no root matches (e.g. the project is opened inside a sub-directory of a repo, so behaviour for that case is unchanged from today).

## Changes

- **`CodewalkerGitOps.kt`** — replaced `firstRepository()` with `primaryRepository()`, backed by a new static helper `pickPrimaryRepository(project)` that implements the project-root preference with first-found fallback. Renamed for clarity since "first" no longer matches the semantics.
- **`GitHubRemoteResolver.kt`** — switched both `resolve` and `resolveResult` to use the same `pickPrimaryRepository` helper. Without this, the prescribed fix in `CodewalkerGitOps` alone would not fix the `IdlePanel` symptom called out in the issue, because `IdlePanel` resolves the remote through `GitHubRemoteResolver`, not through `CodewalkerGitOps`. Centralising the selection means both code paths agree on which repo represents the project.
- **`ReviewSessionController.kt`** — updated the two `gitOps.firstRepository()` callers to `gitOps.primaryRepository()`.
- **`codewalker-intellij-briefing.md`** — appended a paragraph to the git operations section documenting the multi-repo behaviour and pointing at `pickPrimaryRepository` as the single source of truth for the selection.

## Note on the issue scope

The issue prescribed updating `CodewalkerGitOps` only and noted "any caller using `firstRepository()` keeps working unchanged". That is true for `CodewalkerGitOps` callers, but on its own would not fix the `IdlePanel` header symptom — `IdlePanel` goes through `GitHubRemoteResolver`, which had the same `repos.firstNotNullOfOrNull { ... }` pattern. I extended the fix there so the acceptance criterion ("`IdlePanel` header shows the correct `owner/repo` for projects with submodules") actually holds.

## Tests

Per the issue, a unit test for `primaryRepository` is impractical because it depends on real `GitRepositoryManager` state. No new tests added — manual verification per the steps in the issue.

## Build verification

`./gradlew check` could not run in the sandbox (no network access to `download.jetbrains.com` / `cache-redirector.jetbrains.com` / `jitpack.io` to resolve `idea:ideaIC:2025.1`, and the IntelliJ platform is not in the local Gradle cache). CI will run check on this PR.

https://claude.ai/code/session_01KsAutz8DW8rVvP2hyGGokD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsAutz8DW8rVvP2hyGGokD)_